### PR TITLE
Fix: Correct quote type in Mermaid diagram edge labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ graph TD
     end
 
     %% Data flows
-    UI   -->|"“/predict”, “/train”"| API
+    UI   -->|"/predict", "/train"| API
     API  -->|enqueue raw data| IA
     IA   -->|writes tensors| TS
     TS   -->|reads tensors| NQLA
@@ -79,7 +79,7 @@ graph TD
     RLA     -->|policy eval| TOps
     AutoMLA -->|model tuning| TOps
 
-    %% (optionally) have ops write back results to storage
+    %% Ops writing back (optional)
     TOps -->|save intermediates| TS
 ```
 


### PR DESCRIPTION
Ensures that edge labels in the Tensorus execution cycle Mermaid diagram use standard double quotes (") instead of smart quotes (“”) to prevent rendering issues.

This incorporates your latest correction for the diagram.