### PR TITLE
Fix: Remove another invalid comment from f-string in app.py

### DIFF
--- a/tensorus/app.py
+++ b/tensorus/app.py
@@ -353,7 +353,7 @@ def nexus_dashboard_content():
     api_status_icon_class = "api-status-connected" if api_ok else "api-status-disconnected"
     api_icon_char = "✔️" if api_ok else "❌"
     st.markdown(f"""
-    <div class="common-card metric-card {api_status_icon_class}"> {/* Add status class for icon */}
+    <div class="common-card metric-card {api_status_icon_class}">
         <div class="icon">{api_icon_char}</div>
         <h3>API Status</h3>
         <p class="metric-value">{api_status_text}</p>


### PR DESCRIPTION
This commit removes a second Python comment found inside an f-string in tensorus/app.py (around line 356). This was causing a SyntaxError. This resolves the issue you reported following the initial fix.