### PR TITLE
Fix: Correct import path for shared CSS in tensorus/app.py

### DIFF
--- a/tensorus/app.py
+++ b/tensorus/app.py
@@ -388,7 +388,7 @@ def nexus_dashboard_content():
 # --- Main Application ---
 # Import the shared CSS loader
 try:
-    from pages.pages_shared_utils import load_css as load_shared_css
+    from ..pages.pages_shared_utils import load_css as load_shared_css
 except ImportError:
     st.error("Failed to import shared CSS loader. Page styling will be incomplete.")
     def load_shared_css(): pass # Dummy function


### PR DESCRIPTION
Changed the import for `pages_shared_utils.load_css` in `tensorus/app.py` to use a relative path (`..pages.pages_shared_utils`). This is necessary because `app.py` is in a subdirectory (`tensorus/`) while the `pages` directory is at the project root.

This resolves the "Failed to import shared CSS loader" error.