### PR TITLE
Fix: Import Optional in pages_shared_utils.py

### DIFF
--- a/pages/pages_shared_utils.py
+++ b/pages/pages_shared_utils.py
@@ -6,6 +6,7 @@ Copied/adapted from app.py to avoid complex import issues.
 import streamlit as st
 import requests
 import logging
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -492,5 +493,3 @@ def post_nql_query(query: str) -> dict:
     except Exception as e:
         logger.exception(f"Unexpected error in post_nql_query (pages_shared_utils): {e}")
         return {"query": query, "response_text": "An unexpected error occurred.", "error": str(e), "results": None}
-
-```


### PR DESCRIPTION
I added `from typing import Optional` to `tensorus/pages/pages_shared_utils.py` to resolve a `NameError` that occurred because `Optional` was used as a type hint without being imported.