### PR TITLE
Fix: Re-add missing 'from typing import Optional' in pages_shared_uti…

### DIFF
--- a/pages/pages_shared_utils.py
+++ b/pages/pages_shared_utils.py
@@ -6,6 +6,7 @@ Copied/adapted from app.py to avoid complex import issues.
 import streamlit as st
 import requests
 import logging
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
…ls.py

The import statement `from typing import Optional` was missing again from `pages/pages_shared_utils.py`, leading to a `NameError`.

This commit re-adds the necessary import to resolve the error. This issue may have arisen from an earlier repository reset or version mismatch.