### PR TITLE
Fix: Ensure FastAPI server runs and API docs are embeddable

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,9 @@ import requests # Needed for ui_utils functions if integrated
 import logging # Needed for ui_utils functions if integrated
 import torch # Needed for integrated tensor utils
 from typing import List, Dict, Any, Optional, Union, Tuple # Needed for integrated tensor utils
+import multiprocessing
+import uvicorn
+from tensorus.api import app as fastapi_app
 
 # --- Page Configuration ---
 st.set_page_config(
@@ -385,6 +388,12 @@ def nexus_dashboard_content():
     st.markdown('</div>', unsafe_allow_html=True) # Close activity-feed-container
 
 
+# --- FastAPI Server Process ---
+def run_fastapi_server():
+    """Runs the FastAPI server using Uvicorn."""
+    uvicorn.run(fastapi_app, host="127.0.0.1", port=8000, log_level="info")
+
+
 # --- Main Application ---
 # Import the shared CSS loader
 try:
@@ -467,5 +476,10 @@ if __name__ == "__main__":
     if 'dataset_preview' not in st.session_state: st.session_state.dataset_preview = None
     if 'explorer_result' not in st.session_state: st.session_state.explorer_result = None
     if 'nql_response' not in st.session_state: st.session_state.nql_response = None
+
+    # Start FastAPI server in a separate process
+    fastapi_process = multiprocessing.Process(target=run_fastapi_server)
+    fastapi_process.daemon = True
+    fastapi_process.start()
     
     main()

--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -81,7 +81,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
 async def add_security_headers(request: Request, call_next):
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
-    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-Frame-Options"] = "SAMEORIGIN"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Content-Security-Policy"] = "default-src 'self'"
     return response


### PR DESCRIPTION
This commit addresses two issues:
1. The API Playground (api_playground_v2.py) was unable to connect to the FastAPI backend because the server was not being started automatically.
2. Once the server was running, the API documentation pages (/docs, /redoc) could not be embedded in iframes due to the 'X-Frame-Options: DENY' header.

Changes:
- Modified `app.py`:
    - Added multiprocessing and uvicorn to start the FastAPI server (`tensorus.api.app`) in a background daemon process when `app.py` is run. This ensures the API is available for the Streamlit application.
- Modified `tensorus/api.py`:
    - Changed the `X-Frame-Options` header in the `add_security_headers` middleware from `DENY` to `SAMEORIGIN`. This allows the API documentation to be embedded in iframes from the same origin, enabling the API Playground to function correctly.