### PR TITLE
feat: Refactor decompositions and implement TR decomposition

### DIFF
--- a/tensorus/tensor_decompositions.py
+++ b/tensorus/tensor_decompositions.py
@@ -1,0 +1,328 @@
+# tensorus/tensor_decompositions.py
+"""
+Provides a library of tensor decomposition operations for Tensorus.
+This module will contain various tensor decomposition algorithms
+like CP, Tucker, TT, TR, etc.
+"""
+
+import torch
+import tensorly as tl
+from typing import List, Tuple, Union, Optional
+
+# To use utility methods like _check_tensor from TensorOps
+# Assuming tensor_ops.py is in the same directory and can be imported.
+from tensorus.tensor_ops import TensorOps
+import logging
+from tensorly.decomposition import parafac, tucker, tensor_train, tensor_ring # Added tensor_ring
+from tensorly.cp_tensor import cp_to_tensor
+from tensorly.tucker_tensor import tucker_to_tensor
+from tensorly.tt_tensor import tt_to_tensor
+from tensorly.tr_tensor import tr_to_tensor # Added for TR reconstruction
+
+
+class TensorDecompositionOps:
+    """
+    A static library class providing tensor decomposition operations.
+    All methods are static and operate on provided torch.Tensor objects,
+    returning decomposition factors also as torch.Tensor objects.
+    """
+
+    @staticmethod
+    def cp_decomposition(tensor: torch.Tensor, rank: int) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        TensorOps._check_tensor(tensor)
+        if not isinstance(rank, int) or rank <= 0:
+            raise ValueError(f"Rank must be a positive integer, but got {rank}.")
+        if tensor.ndim < 2:
+            raise ValueError(f"CP decomposition requires a tensor with at least 2 dimensions, but got {tensor.ndim} dimensions (shape {tensor.shape}).")
+        logging.info(f"Performing CP decomposition with rank {rank} on tensor of shape {tensor.shape}")
+        try:
+            tl_tensor = tl.tensor(tensor.float().numpy())
+            cp_tensor_tl = parafac(tl_tensor, rank=rank)
+            weights_np = cp_tensor_tl.weights
+            factors_np = cp_tensor_tl.factors
+            if weights_np is not None:
+                torch_weights = torch.from_numpy(weights_np).type(torch.float32)
+            else:
+                logging.warning("CP decomposition returned None for weights. This is unexpected for standard parafac.")
+                raise RuntimeError("CP decomposition failed to return weights.")
+            torch_factors = [torch.from_numpy(factor.copy()).type(torch.float32) for factor in factors_np]
+            logging.info(f"CP decomposition successful. Weights shape: {torch_weights.shape}, Number of factor matrices: {len(torch_factors)}")
+            if torch_factors:
+                 logging.info(f"Shape of first factor matrix: {torch_factors[0].shape}")
+            return torch_weights, torch_factors
+        except Exception as e:
+            logging.error(f"Error during CP decomposition: {e}. Tensor shape: {tensor.shape}, Rank: {rank}")
+            raise RuntimeError(f"CP decomposition failed. Original error: {e}")
+
+    @staticmethod
+    def tucker_decomposition(tensor: torch.Tensor, ranks: List[int]) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        TensorOps._check_tensor(tensor)
+        if not isinstance(ranks, list) or not all(isinstance(r, int) and r > 0 for r in ranks):
+            raise ValueError(f"Ranks must be a list of positive integers, but got {ranks}.")
+        if len(ranks) != tensor.ndim:
+            raise ValueError(f"Length of ranks list ({len(ranks)}) must match tensor dimensionality ({tensor.ndim}).")
+        for i, r_val in enumerate(ranks):
+            if not (1 <= r_val <= tensor.shape[i]):
+                raise ValueError(f"Rank for mode {i} ({r_val}) is out of valid range [1, {tensor.shape[i]}].")
+        logging.info(f"Performing Tucker decomposition with ranks {ranks} on tensor of shape {tensor.shape}")
+        try:
+            tl_tensor = tl.tensor(tensor.float().numpy())
+            core_np, factors_np = tucker(tl_tensor, rank=ranks)
+            torch_core = torch.from_numpy(core_np.copy()).type(torch.float32)
+            torch_factors = [torch.from_numpy(factor.copy()).type(torch.float32) for factor in factors_np]
+            logging.info(f"Tucker decomposition successful. Core tensor shape: {torch_core.shape}, Number of factor matrices: {len(torch_factors)}")
+            if torch_factors:
+                 logging.info(f"Shape of first factor matrix: {torch_factors[0].shape}")
+            return torch_core, torch_factors
+        except Exception as e:
+            logging.error(f"Error during Tucker decomposition: {e}. Tensor shape: {tensor.shape}, Ranks: {ranks}")
+            raise RuntimeError(f"Tucker decomposition failed. Original error: {e}")
+
+    @staticmethod
+    def hosvd(tensor: torch.Tensor) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        TensorOps._check_tensor(tensor)
+        if tensor.ndim < 2:
+            raise ValueError(f"HOSVD requires a tensor with at least 2 dimensions, but got {tensor.ndim} dimensions (shape {tensor.shape}).")
+        ranks = list(tensor.shape)
+        logging.info(f"Performing HOSVD (Tucker with full ranks {ranks}) on tensor of shape {tensor.shape}")
+        try:
+            tl_tensor = tl.tensor(tensor.float().numpy())
+            core_np, factors_np = tucker(tl_tensor, rank=ranks)
+            torch_core = torch.from_numpy(core_np.copy()).type(torch.float32)
+            torch_factors = [torch.from_numpy(factor.copy()).type(torch.float32) for factor in factors_np]
+            logging.info(f"HOSVD successful. Core tensor shape: {torch_core.shape}, Number of factor matrices: {len(torch_factors)}")
+            if torch_factors:
+                 logging.info(f"Shape of first factor matrix: {torch_factors[0].shape}")
+            return torch_core, torch_factors
+        except Exception as e:
+            logging.error(f"Error during HOSVD: {e}. Tensor shape: {tensor.shape}")
+            raise RuntimeError(f"HOSVD failed. Original error: {e}")
+
+    @staticmethod
+    def tt_decomposition(tensor: torch.Tensor, rank: Union[int, List[int]]) -> List[torch.Tensor]:
+        TensorOps._check_tensor(tensor)
+        if tensor.ndim == 0:
+            raise ValueError("TT decomposition requires a tensor with at least 1 dimension, but got 0.")
+        param_for_tensor_train: Union[int, List[int]]
+        if isinstance(rank, int):
+            if rank <= 0:
+                raise ValueError(f"If rank is an integer, it must be positive, but got {rank}.")
+            if tensor.ndim == 1:
+                param_for_tensor_train = 1
+            else:
+                param_for_tensor_train = [1] + [rank] * (tensor.ndim - 1) + [1]
+        elif isinstance(rank, list):
+            if tensor.ndim == 1:
+                if rank:
+                    raise ValueError(f"For a 1D tensor, rank list must be empty for user input, but got {rank}.")
+                param_for_tensor_train = 1
+            else:
+                if len(rank) != tensor.ndim - 1:
+                    raise ValueError(f"Rank list length must be tensor.ndim - 1 ({tensor.ndim - 1}), but got {len(rank)} for tensor of shape {tensor.shape}.")
+                if not all(isinstance(r, int) and r > 0 for r in rank):
+                    raise ValueError(f"All ranks in the list must be positive integers, but got {rank}.")
+                param_for_tensor_train = [1] + rank + [1]
+        else:
+            raise TypeError(f"Rank must be an int or a list of ints, but got {type(rank)}.")
+        logging.info(f"Performing TT decomposition with TensorLy rank parameter {param_for_tensor_train} (user input {rank}) on tensor of shape {tensor.shape}")
+        try:
+            tl_tensor = tl.tensor(tensor.float().numpy())
+            result_tl = tensor_train(tl_tensor, rank=param_for_tensor_train)
+            factors_np: List[tl.ndarray]
+            if hasattr(result_tl, 'factors'):
+                factors_np = result_tl.factors
+            elif isinstance(result_tl, list):
+                factors_np = result_tl
+            elif tensor.ndim == 1 and isinstance(result_tl, tl.ndarray):
+                factors_np = [result_tl]
+            else:
+                raise RuntimeError(f"TensorLy's tensor_train returned an unexpected type: {type(result_tl)}. Value: {result_tl}")
+            torch_factors = [torch.from_numpy(factor.copy()).type(torch.float32) for factor in factors_np]
+            logging.info(f"TT decomposition successful. Number of TT cores: {len(torch_factors)}")
+            if torch_factors:
+                for i, core_factor in enumerate(torch_factors):
+                    logging.info(f"  TT Core {i} shape: {core_factor.shape}")
+            return torch_factors
+        except Exception as e:
+            logging.error(f"Error during TT decomposition: {e}. Tensor shape: {tensor.shape}, Rank(s): {rank}")
+            raise RuntimeError(f"TT decomposition failed. Original error: {e}")
+
+    @staticmethod
+    def tr_decomposition(tensor: torch.Tensor, rank: Union[int, List[int]]) -> List[torch.Tensor]:
+        """
+        Performs Tensor Ring (TR) decomposition on a tensor.
+
+        The TR decomposition factorizes a tensor into a sequence of 3D cores,
+        where the last rank connects back to the first, forming a ring.
+
+        Args:
+            tensor (torch.Tensor): The input tensor to decompose. Must have ndim >= 1.
+            rank (Union[int, List[int]]): The TR-ranks.
+                - If int: The maximum TR-rank (r_k for all k).
+                - If List[int]: A list of N ranks [r_0, r_1, ..., r_{N-1}], where N is
+                  the order of the tensor. The condition r_N = r_0 is implicit.
+
+        Returns:
+            List[torch.Tensor]: A list of TR factor tensors (cores).
+                Each factor G_k is a 3D tensor of shape (rank_{k-1}, tensor.shape[k], rank_k).
+                Note that rank_N is implicitly equal to rank_0.
+
+        Raises:
+            TypeError: If the input `tensor` is not a PyTorch tensor or if `rank` is not an int or list.
+            ValueError: If `tensor.ndim` is 0.
+                        If `rank` is an int and not positive.
+                        If `rank` is a list and its length is not `tensor.ndim`.
+                        If any rank in the list is not positive.
+            RuntimeError: If the TR decomposition fails.
+        """
+        TensorOps._check_tensor(tensor)
+
+        if tensor.ndim == 0:
+            raise ValueError("TR decomposition requires a tensor with at least 1 dimension, but got 0.")
+
+        # Validate user-provided rank and determine the rank parameter for TensorLy's tensor_ring
+        # Based on error messages, this environment's tensor_ring expects N+1 ranks.
+        param_for_tensor_ring: List[int]
+        if isinstance(rank, int): # User provided a single maximum rank
+            if rank <= 0:
+                raise ValueError(f"If rank is an integer, it must be positive, but got {rank}.")
+            param_for_tensor_ring = [rank] * tensor.ndim + [rank] # N+1 elements, r_N = r_0 = rank
+        elif isinstance(rank, list): # User provided a list of N ranks [r_0, ..., r_{N-1}]
+            if len(rank) != tensor.ndim:
+                raise ValueError(f"If rank is a list, its length must be equal to tensor.ndim ({tensor.ndim}), but got {len(rank)} for tensor of shape {tensor.shape}.")
+            if not all(isinstance(r_val, int) and r_val > 0 for r_val in rank):
+                raise ValueError(f"All ranks in the list must be positive integers, but got {rank}.")
+            param_for_tensor_ring = rank + [rank[0]] # Append r_0 to make r_N = r_0, total N+1 elements
+        else:
+            raise TypeError(f"Rank must be an int or a list of ints, but got {type(rank)}.")
+
+        logging.info(f"Performing TR decomposition with TensorLy rank parameter {param_for_tensor_ring} (user input {rank}) on tensor of shape {tensor.shape}")
+
+        try:
+            tl_tensor = tl.tensor(tensor.float().numpy())
+
+            # tensor_ring returns a TensorRing object which has a .factors attribute
+            tr_object_tl = tensor_ring(tl_tensor, rank=param_for_tensor_ring)
+            factors_np = tr_object_tl.factors # This is a list of numpy arrays
+
+            torch_factors = [torch.from_numpy(factor.copy()).type(torch.float32) for factor in factors_np]
+
+            logging.info(f"TR decomposition successful. Number of TR cores: {len(torch_factors)}")
+            if torch_factors:
+                for i, core_factor in enumerate(torch_factors):
+                    logging.info(f"  TR Core {i} shape: {core_factor.shape}")
+
+            return torch_factors
+
+        except Exception as e:
+            logging.error(f"Error during TR decomposition: {e}. Tensor shape: {tensor.shape}, Rank(s): {rank}")
+            raise RuntimeError(f"TR decomposition failed. Original error: {e}")
+
+
+if __name__ == '__main__':
+    print("--- TensorDecompositionOps Examples ---")
+
+    # CP Decomposition Example
+    print("\n--- CP Decomposition Example ---")
+    cp_tensor_data = torch.arange(24, dtype=torch.float32).reshape((2, 3, 4))
+    cp_rank = 2
+    print(f"Original CP tensor shape: {cp_tensor_data.shape}, Rank: {cp_rank}")
+    try:
+        weights_cp, factors_cp = TensorDecompositionOps.cp_decomposition(cp_tensor_data, cp_rank)
+        print(f"CP weights shape: {weights_cp.shape}")
+        print(f"CP factors shapes: {[f.shape for f in factors_cp]}")
+        np_weights_cp = weights_cp.numpy()
+        np_factors_cp = [f.numpy() for f in factors_cp]
+        reconstructed_cp = torch.from_numpy(tl.cp_to_tensor((np_weights_cp, np_factors_cp))).float()
+        error_cp = torch.norm(cp_tensor_data - reconstructed_cp) / torch.norm(cp_tensor_data)
+        print(f"CP reconstruction error: {error_cp.item():.6f}")
+    except Exception as e:
+        print(f"CP example failed: {e}")
+
+    # Tucker Decomposition Example
+    print("\n--- Tucker Decomposition Example ---")
+    tucker_tensor_data = torch.rand(3, 4, 5, dtype=torch.float32)
+    tucker_ranks = [2, 3, 2]
+    print(f"Original Tucker tensor shape: {tucker_tensor_data.shape}, Ranks: {tucker_ranks}")
+    try:
+        core_tucker, factors_tucker = TensorDecompositionOps.tucker_decomposition(tucker_tensor_data, tucker_ranks)
+        print(f"Tucker core shape: {core_tucker.shape}")
+        print(f"Tucker factors shapes: {[f.shape for f in factors_tucker]}")
+        np_core_tucker = core_tucker.numpy()
+        np_factors_tucker = [f.numpy() for f in factors_tucker]
+        reconstructed_tucker = torch.from_numpy(tl.tucker_to_tensor((np_core_tucker, np_factors_tucker))).float()
+        error_tucker = torch.norm(tucker_tensor_data - reconstructed_tucker) / torch.norm(tucker_tensor_data)
+        print(f"Tucker reconstruction error: {error_tucker.item():.4f}")
+    except Exception as e:
+        print(f"Tucker example failed: {e}")
+
+    # HOSVD Example
+    print("\n--- HOSVD Example ---")
+    hosvd_tensor_data = torch.rand(2, 3, 4, dtype=torch.float32)
+    print(f"Original HOSVD tensor shape: {hosvd_tensor_data.shape}")
+    try:
+        core_hosvd, factors_hosvd = TensorDecompositionOps.hosvd(hosvd_tensor_data)
+        print(f"HOSVD core shape: {core_hosvd.shape}")
+        print(f"HOSVD factors shapes: {[f.shape for f in factors_hosvd]}")
+        for i, factor_h in enumerate(factors_hosvd):
+            identity_approx = torch.matmul(factor_h.T, factor_h)
+            print(f"  Factor {i} orthogonality check (vs Identity): {torch.allclose(identity_approx, torch.eye(factor_h.shape[1]), atol=1e-5)}")
+        np_core_hosvd = core_hosvd.numpy()
+        np_factors_hosvd = [f.numpy() for f in factors_hosvd]
+        reconstructed_hosvd = torch.from_numpy(tl.tucker_to_tensor((np_core_hosvd, np_factors_hosvd))).float()
+        error_hosvd = torch.norm(hosvd_tensor_data - reconstructed_hosvd) / torch.norm(hosvd_tensor_data)
+        print(f"HOSVD reconstruction error: {error_hosvd.item():.6f}")
+    except Exception as e:
+        print(f"HOSVD example failed: {e}")
+
+    # TT Decomposition Example (3D)
+    print("\n--- TT Decomposition Example (3D) ---")
+    tt_3d_tensor_data = torch.rand(3, 4, 5, dtype=torch.float32)
+    tt_3d_ranks = [2, 3]
+    print(f"Original TT 3D tensor shape: {tt_3d_tensor_data.shape}, Internal Ranks: {tt_3d_ranks}")
+    try:
+        factors_tt_3d = TensorDecompositionOps.tt_decomposition(tt_3d_tensor_data, tt_3d_ranks)
+        print(f"TT 3D factors shapes: {[f.shape for f in factors_tt_3d]}")
+        np_factors_tt_3d = [f.numpy() for f in factors_tt_3d]
+        reconstructed_tt_3d = torch.from_numpy(tl.tt_to_tensor(np_factors_tt_3d)).float()
+        error_tt_3d = torch.norm(tt_3d_tensor_data - reconstructed_tt_3d) / torch.norm(tt_3d_tensor_data)
+        print(f"TT 3D reconstruction error: {error_tt_3d.item():.4f}")
+    except Exception as e:
+        print(f"TT 3D example failed: {e}")
+
+    # TT Decomposition Example (1D - expected to fail based on previous findings)
+    print("\n--- TT Decomposition Example (1D) ---")
+    tt_1d_tensor_data = torch.rand(10, dtype=torch.float32)
+    tt_1d_rank = []
+    print(f"Original TT 1D tensor shape: {tt_1d_tensor_data.shape}, User Rank: {tt_1d_rank}")
+    try:
+        factors_tt_1d = TensorDecompositionOps.tt_decomposition(tt_1d_tensor_data, tt_1d_rank)
+        print(f"TT 1D factors shapes: {[f.shape for f in factors_tt_1d]}")
+    except RuntimeError as e:
+        print(f"TT 1D example failed as expected: {e}")
+    except Exception as e:
+        print(f"An unexpected error in TT 1D example: {e}")
+
+    # TR Decomposition Example
+    print("\n--- TR Decomposition Example ---")
+    # Using a slightly larger tensor and smaller ranks to avoid SVD issues.
+    tr_tensor_data = torch.rand(4, 5, 6, dtype=torch.float32) # 3D tensor
+    tr_ranks = [2, 2, 2] # Ranks [r0, r1, r2], r2 implicitly connects to r0 for reconstruction.
+                         # TensorLy's tensor_ring takes these N ranks.
+    print(f"Original TR tensor shape: {tr_tensor_data.shape}, Ranks: {tr_ranks}")
+    try:
+        factors_tr = TensorDecompositionOps.tr_decomposition(tr_tensor_data, tr_ranks)
+        print(f"TR factors shapes: {[f.shape for f in factors_tr]}")
+        # Expected shapes for 3D (I0,I1,I2)=(4,5,6) and ranks [r0,r1,r2]=[2,2,2]:
+        # G0: (r2, I0, r0) = (2, 4, 2)
+        # G1: (r0, I1, r1) = (2, 5, 2)
+        # G2: (r1, I2, r2) = (2, 6, 2)
+
+        np_factors_tr = [f.numpy() for f in factors_tr]
+        reconstructed_tr = torch.from_numpy(tl.tr_to_tensor(np_factors_tr)).float()
+        error_tr = torch.norm(tr_tensor_data - reconstructed_tr) / torch.norm(tr_tensor_data)
+        print(f"TR reconstruction error: {error_tr.item():.4f}")
+    except Exception as e:
+        print(f"TR example failed: {e}")
+
+    print("\n--- All Decomposition Examples Finished ---")

--- a/tensorus/tensor_ops.py
+++ b/tensorus/tensor_ops.py
@@ -18,7 +18,7 @@ import logging
 from typing import Tuple, Optional, List, Union
 
 import tensorly as tl
-from tensorly.decomposition import parafac, tucker, tensor_train
+# All decomposition imports (parafac, tucker, tensor_train) are now removed.
 # CPTensor is a namedtuple, can be used for type hinting if specific
 # from tensorly.cp_tensor import CPTensor
 
@@ -326,297 +326,11 @@ class TensorOps:
 
     # --- Tensor Decomposition Operations ---
 
-    @staticmethod
-    def cp_decomposition(tensor: torch.Tensor, rank: int) -> Tuple[torch.Tensor, List[torch.Tensor]]:
-        """
-        Performs CP (CANDECOMP/PARAFAC) decomposition on a tensor.
-
-        The CP decomposition factorizes a tensor into a sum of rank-one tensors.
-        It returns weights and a list of factor matrices.
-
-        Args:
-            tensor (torch.Tensor): The input tensor to decompose.
-            rank (int): The desired rank of the decomposition.
-
-        Returns:
-            Tuple[torch.Tensor, List[torch.Tensor]]: A tuple containing:
-                - torch_weights (torch.Tensor): A 1D tensor of weights.
-                - torch_factors (List[torch.Tensor]): A list of factor matrices.
-                  Each factor matrix has `rank` columns.
-
-        Raises:
-            TypeError: If the input `tensor` is not a PyTorch tensor.
-            ValueError: If `rank` is not a positive integer.
-            ValueError: If the input `tensor` has fewer than 2 dimensions.
-            RuntimeError: If the CP decomposition fails (e.g., convergence issues).
-        """
-        TensorOps._check_tensor(tensor)
-
-        if not isinstance(rank, int) or rank <= 0:
-            raise ValueError(f"Rank must be a positive integer, but got {rank}.")
-
-        if tensor.ndim < 2:
-            raise ValueError(f"CP decomposition requires a tensor with at least 2 dimensions, but got {tensor.ndim} dimensions (shape {tensor.shape}).")
-
-        logging.info(f"Performing CP decomposition with rank {rank} on tensor of shape {tensor.shape}")
-
-        try:
-            # Convert to float32 for tensorly operations, common in ML
-            tl_tensor = tl.tensor(tensor.float().numpy())
-
-            # Perform CP decomposition using TensorLy
-            # parafac returns a CPTensor instance (namedtuple: (weights, factors))
-            cp_tensor_tl = parafac(tl_tensor, rank=rank)
-
-            weights_np = cp_tensor_tl.weights
-            factors_np = cp_tensor_tl.factors
-
-            # Convert weights and factors back to PyTorch tensors, maintaining float32
-            if weights_np is not None:
-                torch_weights = torch.from_numpy(weights_np).type(torch.float32)
-            else:
-                # Handle cases where weights might be absorbed or not returned distinctly
-                # For now, assume weights are always returned. If not, this might need adjustment
-                # e.g., return torch.ones(rank, dtype=torch.float32) or raise error.
-                # Based on TensorLy's standard parafac, weights should be present.
-                logging.warning("CP decomposition returned None for weights. This is unexpected for standard parafac.")
-                # Fallback or error based on expected behavior. For now, let's assume it's an error if None.
-                raise RuntimeError("CP decomposition failed to return weights.")
-
-            torch_factors = [torch.from_numpy(factor).type(torch.float32) for factor in factors_np]
-
-            logging.info(f"CP decomposition successful. Weights shape: {torch_weights.shape}, Number of factor matrices: {len(torch_factors)}")
-            if torch_factors:
-                 logging.info(f"Shape of first factor matrix: {torch_factors[0].shape}")
-
-            return torch_weights, torch_factors
-
-        except Exception as e:
-            logging.error(f"Error during CP decomposition: {e}. Tensor shape: {tensor.shape}, Rank: {rank}")
-            # Re-raise as a RuntimeError to signal failure in the operation
-            raise RuntimeError(f"CP decomposition failed. Original error: {e}")
-
-    @staticmethod
-    def hosvd(tensor: torch.Tensor) -> Tuple[torch.Tensor, List[torch.Tensor]]:
-        """
-        Performs Higher-Order Singular Value Decomposition (HOSVD) on a tensor.
-
-        HOSVD is a specific case of Tucker decomposition where the factor matrices
-        are constrained to be orthogonal. It decomposes the input tensor into a
-        core tensor and a list of orthogonal factor matrices, one for each mode.
-        The ranks for HOSVD are taken to be the full dimensions of the tensor.
-
-        Args:
-            tensor (torch.Tensor): The input tensor to decompose. Must have at
-                                   least 1 dimension.
-
-        Returns:
-            Tuple[torch.Tensor, List[torch.Tensor]]: A tuple containing:
-                - torch_core (torch.Tensor): The core tensor of the HOSVD.
-                  Its shape will be the same as the input tensor.
-                - torch_factors (List[torch.Tensor]): A list of orthogonal
-                  factor matrices. `torch_factors[i]` will have shape
-                  `(tensor.shape[i], tensor.shape[i])`.
-
-        Raises:
-            TypeError: If the input `tensor` is not a PyTorch tensor.
-            ValueError: If the input `tensor` has less than 1 dimension.
-            RuntimeError: If the HOSVD (via Tucker decomposition) fails.
-        """
-        TensorOps._check_tensor(tensor)
-
-        if tensor.ndim < 2:
-            # HOSVD is typically defined for tensors of order 2 or higher.
-            # TensorLy's TuckerTensor representation also expects at least 2 factors.
-            raise ValueError(f"HOSVD requires a tensor with at least 2 dimensions, but got {tensor.ndim} dimensions (shape {tensor.shape}).")
-
-        # For HOSVD, ranks are the full dimensions of the tensor.
-        ranks = list(tensor.shape)
-
-        logging.info(f"Performing HOSVD (Tucker with full ranks {ranks}) on tensor of shape {tensor.shape}")
-
-        try:
-            # Convert to float32 for tensorly operations
-            tl_tensor = tl.tensor(tensor.float().numpy())
-
-            # Perform HOSVD using TensorLy's tucker with full ranks and init='svd' (default)
-            # This ensures orthogonal factors are computed via SVD of unfoldings.
-            core_np, factors_np = tucker(tl_tensor, rank=ranks) # init='svd' is default
-
-            # Convert core tensor and factors back to PyTorch tensors
-            torch_core = torch.from_numpy(core_np.copy()).type(torch.float32)
-            torch_factors = [torch.from_numpy(factor.copy()).type(torch.float32) for factor in factors_np]
-
-            logging.info(f"HOSVD successful. Core tensor shape: {torch_core.shape}, Number of factor matrices: {len(torch_factors)}")
-            if torch_factors:
-                 logging.info(f"Shape of first factor matrix: {torch_factors[0].shape}")
-
-            return torch_core, torch_factors
-
-        except Exception as e:
-            logging.error(f"Error during HOSVD: {e}. Tensor shape: {tensor.shape}")
-            # Re-raise as a RuntimeError to signal failure
-            raise RuntimeError(f"HOSVD failed. Original error: {e}")
-
-    @staticmethod
-    def tucker_decomposition(tensor: torch.Tensor, ranks: List[int]) -> Tuple[torch.Tensor, List[torch.Tensor]]:
-        """
-        Performs Tucker decomposition on a tensor.
-
-        The Tucker decomposition factorizes a tensor into a core tensor and a set
-        of factor matrices for each mode.
-
-        Args:
-            tensor (torch.Tensor): The input tensor to decompose.
-            ranks (List[int]): A list of desired ranks for each mode of the tensor.
-                               The length of the list must match the number of
-                               dimensions of the input tensor.
-
-        Returns:
-            Tuple[torch.Tensor, List[torch.Tensor]]: A tuple containing:
-                - torch_core (torch.Tensor): The core tensor of the decomposition.
-                  Its shape will be according to the specified `ranks`.
-                - torch_factors (List[torch.Tensor]): A list of factor matrices.
-                  Each factor matrix `torch_factors[i]` will have shape
-                  `(tensor.shape[i], ranks[i])`.
-
-        Raises:
-            TypeError: If the input `tensor` is not a PyTorch tensor.
-            ValueError: If `ranks` is not a list of positive integers,
-                        if its length does not match `tensor.ndim`, or
-                        if any rank is not `1 <= rank_i <= tensor.shape[i]`.
-            RuntimeError: If the Tucker decomposition fails.
-        """
-        TensorOps._check_tensor(tensor)
-
-        if not isinstance(ranks, list) or not all(isinstance(r, int) and r > 0 for r in ranks):
-            raise ValueError(f"Ranks must be a list of positive integers, but got {ranks}.")
-
-        if len(ranks) != tensor.ndim:
-            raise ValueError(f"Length of ranks list ({len(ranks)}) must match tensor dimensionality ({tensor.ndim}).")
-
-        for i, r in enumerate(ranks):
-            if not (1 <= r <= tensor.shape[i]):
-                raise ValueError(f"Rank for mode {i} ({r}) is out of valid range [1, {tensor.shape[i]}].")
-
-        logging.info(f"Performing Tucker decomposition with ranks {ranks} on tensor of shape {tensor.shape}")
-
-        try:
-            # Convert to float32 for tensorly operations
-            tl_tensor = tl.tensor(tensor.float().numpy())
-
-            # Perform Tucker decomposition using TensorLy
-            # tucker returns (core, [factor_matrix_0, ..., factor_matrix_N])
-            core_np, factors_np = tucker(tl_tensor, rank=ranks)
-
-            # Convert core tensor and factors back to PyTorch tensors, maintaining float32
-            # Using .copy() as TensorLy might return views from its operations
-            torch_core = torch.from_numpy(core_np.copy()).type(torch.float32)
-            torch_factors = [torch.from_numpy(factor.copy()).type(torch.float32) for factor in factors_np]
-
-            logging.info(f"Tucker decomposition successful. Core tensor shape: {torch_core.shape}, Number of factor matrices: {len(torch_factors)}")
-            if torch_factors:
-                 logging.info(f"Shape of first factor matrix: {torch_factors[0].shape}")
-
-            return torch_core, torch_factors
-
-        except Exception as e:
-            logging.error(f"Error during Tucker decomposition: {e}. Tensor shape: {tensor.shape}, Ranks: {ranks}")
-            # Re-raise as a RuntimeError to signal failure in the operation
-            raise RuntimeError(f"Tucker decomposition failed. Original error: {e}")
-
-    @staticmethod
-    def tt_decomposition(tensor: torch.Tensor, rank: Union[int, List[int]]) -> List[torch.Tensor]:
-        """
-        Performs Tensor Train (TT) decomposition on a tensor.
-
-        The TT decomposition factorizes a tensor into a sequence of 3D cores
-        (factors). Also known as Matrix Product State (MPS) decomposition.
-
-        Args:
-            tensor (torch.Tensor): The input tensor to decompose. Must have ndim >= 1.
-            rank (Union[int, List[int]]): The TT-ranks.
-                - If int: the maximum TT-rank.
-                - If List[int]: the list of internal TT-ranks [r_1, ..., r_{N-1}],
-                  where N is the order of the tensor. The length of the list must
-                  be tensor.ndim - 1. Boundary ranks r_0 and r_N are implicitly 1.
-
-        Returns:
-            List[torch.Tensor]: A list of TT factor tensors (cores).
-                Each factor G_k is a 3D tensor of shape (rank_{k-1}, tensor.shape[k], rank_k).
-                For the first core G_0, shape is (1, tensor.shape[0], rank_1).
-                For the last core G_{N-1}, shape is (rank_{N-1}, tensor.shape[N-1], 1).
-
-        Raises:
-            TypeError: If the input `tensor` is not a PyTorch tensor.
-            ValueError: If `tensor.ndim` is 0.
-                        If `rank` is an int and not positive.
-                        If `rank` is a list and its length is not `tensor.ndim - 1` (for ndim > 1),
-                        or if it's not empty (for ndim == 1).
-                        If any rank in the list is not positive.
-            RuntimeError: If the TT decomposition fails.
-        """
-        TensorOps._check_tensor(tensor)
-
-        if tensor.ndim == 0:
-            raise ValueError("TT decomposition requires a tensor with at least 1 dimension, but got 0.")
-
-        # Validate user-provided rank and determine the rank parameter for TensorLy's tensor_train
-        param_for_tensor_train: Union[int, List[int]]
-        if isinstance(rank, int): # User provided a single maximum internal rank
-            if rank <= 0:
-                raise ValueError(f"If rank is an integer, it must be positive, but got {rank}.")
-            if tensor.ndim == 1:
-                param_for_tensor_train = 1 # tensor_train for 1D tensor expects rank=1 (int)
-            else:
-                # Assuming the tensor_train in env expects full N+1 ranks list
-                param_for_tensor_train = [1] + [rank] * (tensor.ndim - 1) + [1]
-        elif isinstance(rank, list): # User provided a list of N-1 internal ranks
-            if tensor.ndim == 1:
-                if rank: # Non-empty list for 1D tensor
-                    raise ValueError(f"For a 1D tensor, rank list must be empty for user input, but got {rank}.")
-                param_for_tensor_train = 1 # tensor_train for 1D tensor expects rank=1 (int)
-            else: # tensor.ndim > 1
-                if len(rank) != tensor.ndim - 1:
-                    raise ValueError(f"Rank list length must be tensor.ndim - 1 ({tensor.ndim - 1}), but got {len(rank)} for tensor of shape {tensor.shape}.")
-                if not all(isinstance(r, int) and r > 0 for r in rank):
-                    raise ValueError(f"All ranks in the list must be positive integers, but got {rank}.")
-                # Assuming the tensor_train in env expects full N+1 ranks list
-                param_for_tensor_train = [1] + rank + [1]
-        else:
-            raise TypeError(f"Rank must be an int or a list of ints, but got {type(rank)}.")
-
-        logging.info(f"Performing TT decomposition with TensorLy rank parameter {param_for_tensor_train} (user input {rank}) on tensor of shape {tensor.shape}")
-
-        try:
-            tl_tensor = tl.tensor(tensor.float().numpy())
-
-            # Perform TT decomposition using TensorLy
-            result_tl = tensor_train(tl_tensor, rank=param_for_tensor_train)
-
-            factors_np: List[np.ndarray]
-            if hasattr(result_tl, 'factors'): # Modern TensorLy (>=0.8.0) returns TensorTrain object
-                factors_np = result_tl.factors
-            elif isinstance(result_tl, list): # Older TensorLy might return list of factors
-                factors_np = result_tl
-            elif tensor.ndim == 1 and isinstance(result_tl, tl.ndarray): # Handle 1D case if it returns a single factor array
-                factors_np = [result_tl]
-            else: # Unexpected return type
-                raise RuntimeError(f"TensorLy's tensor_train returned an unexpected type: {type(result_tl)}. Value: {result_tl}")
-
-            # Convert factors back to PyTorch tensors
-            torch_factors = [torch.from_numpy(factor.copy()).type(torch.float32) for factor in factors_np]
-
-            logging.info(f"TT decomposition successful. Number of TT cores: {len(torch_factors)}")
-            if torch_factors:
-                for i, core_factor in enumerate(torch_factors):
-                    logging.info(f"  TT Core {i} shape: {core_factor.shape}")
-
-            return torch_factors
-
-        except Exception as e:
-            logging.error(f"Error during TT decomposition: {e}. Tensor shape: {tensor.shape}, Rank(s): {rank}")
-            raise RuntimeError(f"TT decomposition failed. Original error: {e}")
+    # cp_decomposition method has been moved to tensor_decompositions.py
+    # tucker_decomposition method has been moved to tensor_decompositions.py
+    # hosvd method has been moved to tensor_decompositions.py
+    # tt_decomposition method has been moved to tensor_decompositions.py
+    # All decomposition methods are now in TensorDecompositionOps
 
 
 # Example Usage
@@ -675,148 +389,39 @@ if __name__ == "__main__":
          print(f"Caught expected shape error: {e}")
 
     print("\n--- Tensor Decomposition ---")
-    # Example for CP Decomposition
-    # Create a synthetic 3D tensor
-    data = torch.arange(24, dtype=torch.float32).reshape((2, 3, 4))
-    rank_to_decompose = 2
-    print(f"Original tensor shape for CP: {data.shape}")
-    try:
-        weights, factors = TensorOps.cp_decomposition(data, rank=rank_to_decompose)
-        print(f"CP Decomposition (Rank {rank_to_decompose}):")
-        print(f"  Weights shape: {weights.shape}")
-        print(f"  Number of factors: {len(factors)}")
-        for i, factor in enumerate(factors):
-            print(f"  Factor {i} shape: {factor.shape}")
-
-        # Example with a 2D tensor (matrix)
-        matrix_data = torch.rand(5, 4)
-        rank_matrix_decompose = 3
-        print(f"\nOriginal matrix shape for CP: {matrix_data.shape}")
-        weights_matrix, factors_matrix = TensorOps.cp_decomposition(matrix_data, rank=rank_matrix_decompose)
-        print(f"CP Decomposition (Rank {rank_matrix_decompose}) for matrix:")
-        print(f"  Weights shape: {weights_matrix.shape}")
-        print(f"  Number of factors: {len(factors_matrix)}")
-        for i, factor in enumerate(factors_matrix):
-            print(f"  Factor {i} shape: {factor.shape}")
-
-    except RuntimeError as e:
-        print(f"CP Decomposition example failed: {e}")
-    except FileNotFoundError:
-        print("TensorLy or its dependencies might not be installed. Skipping CP decomposition example.")
-    except Exception as e: # Catch any other unexpected errors during example run
-        print(f"An unexpected error occurred in CP decomposition example: {e}")
+    # CP Decomposition example removed as method moved to TensorDecompositionOps
+    # print(f"Original tensor shape for CP: {{data.shape}}") would have been here.
+    # try:
+    #     from tensorus.tensor_decompositions import TensorDecompositionOps # Import for example
+    #     # ... (rest of CP example using TensorDecompositionOps.cp_decomposition)
+    # except ImportError:
+    #     print("Could not import TensorDecompositionOps for CP example.")
+    # except Exception as e:
+    #     print(f"An error occurred running CP example via TensorDecompositionOps: {e}")
 
 
-    # Example for Tucker Decomposition
-    data_tucker = torch.rand(3, 4, 5, dtype=torch.float32) # Example 3D tensor
-    # Ranks for each mode - must be <= corresponding dimension
-    ranks_tucker = [2, 3, 2]
-    print(f"\nOriginal tensor shape for Tucker: {data_tucker.shape}, Ranks: {ranks_tucker}")
-    try:
-        core, factors_tucker = TensorOps.tucker_decomposition(data_tucker, ranks_tucker)
-        print(f"Tucker Decomposition (Ranks {ranks_tucker}):")
-        print(f"  Core tensor shape: {core.shape}") # Expected: (ranks_tucker[0], ranks_tucker[1], ranks_tucker[2])
-        print(f"  Number of factors: {len(factors_tucker)}")
-        for i, factor in enumerate(factors_tucker):
-            print(f"  Factor {i} shape: {factor.shape}") # Expected: (data_tucker.shape[i], ranks_tucker[i])
-
-        # Optional: Reconstruction example
-        # Convert core and factors back to NumPy for TensorLy's tucker_to_tensor
-        core_np_rec = core.numpy()
-        factors_np_rec = [f.numpy() for f in factors_tucker]
-        reconstructed_tl = tl.tucker_to_tensor((core_np_rec, factors_np_rec))
-        reconstructed_torch = torch.from_numpy(reconstructed_tl).float()
-
-        error = torch.norm(data_tucker - reconstructed_torch) / torch.norm(data_tucker)
-        print(f"  Reconstruction error (relative): {error.item():.4f}")
-
-    except RuntimeError as e:
-        print(f"Tucker Decomposition example failed: {e}")
-    except FileNotFoundError: # In case tensorly was not installed by previous examples
-        print("TensorLy or its dependencies might not be installed. Skipping Tucker decomposition example.")
-    except Exception as e:
-        print(f"An unexpected error occurred in Tucker decomposition example: {e}")
+    # Example for Tucker Decomposition (now moved to TensorDecompositionOps)
+    # print(f"\nOriginal tensor shape for Tucker: {{data_tucker.shape}}, Ranks: {{ranks_tucker}}")
+    # try:
+    #     from tensorus.tensor_decompositions import TensorDecompositionOps # Import for example
+    #     # ... (rest of Tucker example using TensorDecompositionOps.tucker_decomposition)
+    # except ImportError:
+    #     print("Could not import TensorDecompositionOps for Tucker example.")
+    # except Exception as e:
+    #      print(f"An error occurred running Tucker example via TensorDecompositionOps: {e}")
 
 
-    # Example for HOSVD
-    data_hosvd = torch.rand(2, 3, 4, dtype=torch.float32) # Example 3D tensor
-    print(f"\nOriginal tensor shape for HOSVD: {data_hosvd.shape}")
-    try:
-        core_hosvd, factors_hosvd = TensorOps.hosvd(data_hosvd)
-        print("HOSVD:")
-        print(f"  Core tensor shape: {core_hosvd.shape}") # Expected: same as data_hosvd.shape
-        print(f"  Number of factors: {len(factors_hosvd)}")
-        for i, factor in enumerate(factors_hosvd):
-            print(f"  Factor {i} shape: {factor.shape}") # Expected: (data_hosvd.shape[i], data_hosvd.shape[i])
-            # Verify orthogonality: factor.T @ factor should be close to identity
-            identity_approx = torch.matmul(factor.T, factor)
-            identity_check = torch.allclose(identity_approx, torch.eye(factor.shape[1]), atol=1e-5)
-            print(f"  Factor {i} orthogonality check: {identity_check}")
-
-        # Reconstruction (should be near perfect for HOSVD with full ranks)
-        # Convert core and factors back to NumPy for TensorLy's tucker_to_tensor
-        core_np_rec_h = core_hosvd.numpy()
-        factors_np_rec_h = [f.numpy() for f in factors_hosvd]
-        reconstructed_tl_h = tl.tucker_to_tensor((core_np_rec_h, factors_np_rec_h))
-        reconstructed_torch_h = torch.from_numpy(reconstructed_tl_h).float()
-
-        error_h = torch.norm(data_hosvd - reconstructed_torch_h) / torch.norm(data_hosvd)
-        print(f"  Reconstruction error (relative): {error_h.item():.6f}") # Expect very low error
-
-    except RuntimeError as e:
-        print(f"HOSVD example failed: {e}")
-    except Exception as e:
-        print(f"An unexpected error occurred in HOSVD example: {e}")
+    # Example for HOSVD (now moved to TensorDecompositionOps)
+    # print(f"\nOriginal tensor shape for HOSVD: {{data_hosvd.shape}}")
+    # try:
+    #     from tensorus.tensor_decompositions import TensorDecompositionOps
+    #     # ... (rest of HOSVD example using TensorDecompositionOps.hosvd)
+    # except ImportError:
+    #     print("Could not import TensorDecompositionOps for HOSVD example.")
+    # except Exception as e:
+    #     print(f"An error occurred running HOSVD example via TensorDecompositionOps: {e}")
 
 
-    # Example for Tensor Train (TT) Decomposition
-    # For a 3D tensor of shape (I0, I1, I2)
-    data_tt_3d = torch.rand(3, 4, 5, dtype=torch.float32)
-    # Internal ranks [r1, r2] for a 3D tensor (N=3, N-1=2 ranks)
-    ranks_tt_3d = [2, 3]
-    print(f"\nOriginal tensor shape for TT (3D): {data_tt_3d.shape}, Internal Ranks: {ranks_tt_3d}")
-    try:
-        factors_tt_3d = TensorOps.tt_decomposition(data_tt_3d, ranks_tt_3d)
-        print("TT Decomposition (3D):")
-        for i, factor in enumerate(factors_tt_3d):
-            print(f"  TT Core {i} shape: {factor.shape}")
-            # Expected shapes for 3D tensor (I0,I1,I2) and ranks [r1,r2]:
-            # G0: (1, I0, r1)
-            # G1: (r1, I1, r2)
-            # G2: (r2, I2, 1)
-
-        # Optional: Reconstruction example
-        # Convert factors back to NumPy for TensorLy's tt_to_tensor
-        factors_np_rec_tt = [f.numpy() for f in factors_tt_3d]
-        reconstructed_tl_tt = tl.tt_to_tensor(factors_np_rec_tt) # Pass list of factors directly
-        reconstructed_torch_tt = torch.from_numpy(reconstructed_tl_tt).float()
-
-        error_tt_3d = torch.norm(data_tt_3d - reconstructed_torch_tt) / torch.norm(data_tt_3d)
-        print(f"  Reconstruction error (3D, relative): {error_tt_3d.item():.4f}")
-
-    except RuntimeError as e:
-        print(f"TT Decomposition example (3D) failed: {e}")
-    except Exception as e:
-        print(f"An unexpected error in TT (3D) example: {e}")
-
-    # For a 1D tensor (vector)
-    data_tt_1d = torch.rand(10, dtype=torch.float32)
-    ranks_tt_1d = [] # Empty list for 1D tensor, will be handled as rank=1 internally
-    print(f"\nOriginal tensor shape for TT (1D): {data_tt_1d.shape}, Internal Ranks: {ranks_tt_1d} (becomes rank=1)")
-    try:
-        factors_tt_1d = TensorOps.tt_decomposition(data_tt_1d, ranks_tt_1d)
-        print("TT Decomposition (1D):")
-        for i, factor in enumerate(factors_tt_1d):
-            print(f"  TT Core {i} shape: {factor.shape}") # Expected: G0: (1, I0, 1)
-
-        factors_np_rec_tt_1d = [f.numpy() for f in factors_tt_1d]
-        reconstructed_tl_tt_1d = tl.tt_to_tensor(factors_np_rec_tt_1d)
-        reconstructed_torch_tt_1d = torch.from_numpy(reconstructed_tl_tt_1d).float()
-        error_tt_1d = torch.norm(data_tt_1d - reconstructed_torch_tt_1d) / torch.norm(data_tt_1d)
-        print(f"  Reconstruction error (1D, relative): {error_tt_1d.item():.6f}")
-
-
-    except RuntimeError as e:
-        print(f"TT Decomposition example (1D) failed: {e}")
-    except Exception as e:
-        print(f"An unexpected error in TT (1D) example: {e}")
+    # All Tensor Decomposition examples have been moved to tensor_decompositions.py
+    # and should be run from there if needed.
+    print("\n--- Tensor Decomposition examples have been moved to tensor_decompositions.py ---")

--- a/tests/test_tensor_ops.py
+++ b/tests/test_tensor_ops.py
@@ -13,6 +13,7 @@ import os
 # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))) # No longer needed
 
 from tensorus.tensor_ops import TensorOps
+from tensorus.tensor_decompositions import TensorDecompositionOps # Added import
 
 class TestTensorOps(unittest.TestCase):
 
@@ -201,7 +202,7 @@ class TestTensorOps(unittest.TestCase):
         low_rank_tensor_tl = tl.cp_to_tensor((true_weights_np, true_factors_np))
         low_rank_tensor_torch = torch.from_numpy(low_rank_tensor_tl).float()
 
-        weights, factors = TensorOps.cp_decomposition(low_rank_tensor_torch, rank)
+        weights, factors = TensorDecompositionOps.cp_decomposition(low_rank_tensor_torch, rank) # Changed here
 
         self.assertIsInstance(weights, torch.Tensor)
         self.assertIsInstance(factors, list)
@@ -229,7 +230,7 @@ class TestTensorOps(unittest.TestCase):
         sample_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
         rank = 3
 
-        weights, factors = TensorOps.cp_decomposition(sample_tensor, rank)
+        weights, factors = TensorDecompositionOps.cp_decomposition(sample_tensor, rank) # Changed here
 
         self.assertIsInstance(weights, torch.Tensor)
         self.assertIsInstance(factors, list)
@@ -257,7 +258,7 @@ class TestTensorOps(unittest.TestCase):
         matrix_data = torch.rand(6, 7, dtype=torch.float32)
         rank = 2
 
-        weights, factors = TensorOps.cp_decomposition(matrix_data, rank)
+        weights, factors = TensorDecompositionOps.cp_decomposition(matrix_data, rank) # Changed here
 
         self.assertIsInstance(weights, torch.Tensor)
         self.assertIsInstance(factors, list)
@@ -281,26 +282,26 @@ class TestTensorOps(unittest.TestCase):
         """Test CP decomposition with invalid ranks."""
         sample_tensor = torch.rand(2, 2, 2, dtype=torch.float32)
         with self.assertRaisesRegex(ValueError, "Rank must be a positive integer"):
-            TensorOps.cp_decomposition(sample_tensor, 0)
+            TensorDecompositionOps.cp_decomposition(sample_tensor, 0) # Changed here
         with self.assertRaisesRegex(ValueError, "Rank must be a positive integer"):
-            TensorOps.cp_decomposition(sample_tensor, -1)
+            TensorDecompositionOps.cp_decomposition(sample_tensor, -1) # Changed here
         with self.assertRaisesRegex(ValueError, "Rank must be a positive integer"):
-            TensorOps.cp_decomposition(sample_tensor, 1.5) # type: ignore
+            TensorDecompositionOps.cp_decomposition(sample_tensor, 1.5) # Changed here; type: ignore
 
     def test_cp_decomposition_invalid_tensor_ndim(self):
         """Test CP decomposition with tensor of invalid number of dimensions."""
         one_d_tensor = torch.rand(5, dtype=torch.float32)
         with self.assertRaisesRegex(ValueError, "CP decomposition requires a tensor with at least 2 dimensions"):
-            TensorOps.cp_decomposition(one_d_tensor, 2)
+            TensorDecompositionOps.cp_decomposition(one_d_tensor, 2) # Changed here
 
     def test_cp_decomposition_type_error(self):
         """Test CP decomposition with non-tensor input."""
         with self.assertRaisesRegex(TypeError, "Input at index 0 is not a torch.Tensor"):
-            TensorOps.cp_decomposition("not a tensor", 2) # type: ignore
+            TensorDecompositionOps.cp_decomposition("not a tensor", 2) # Changed here; type: ignore
 
         # Test with list of numbers (should also fail _check_tensor)
         with self.assertRaisesRegex(TypeError, "Input at index 0 is not a torch.Tensor"):
-            TensorOps.cp_decomposition([1,2,3], 2) # type: ignore
+            TensorDecompositionOps.cp_decomposition([1,2,3], 2) # Changed here; type: ignore
 
     # --- Test Tucker Decomposition ---
 
@@ -316,7 +317,7 @@ class TestTensorOps(unittest.TestCase):
         low_rank_tensor_tl = tl.tucker_to_tensor((true_core_np, true_factors_np))
         low_rank_tensor_torch = torch.from_numpy(low_rank_tensor_tl).float()
 
-        core, factors = TensorOps.tucker_decomposition(low_rank_tensor_torch, ranks)
+        core, factors = TensorDecompositionOps.tucker_decomposition(low_rank_tensor_torch, ranks) # Changed here
 
         self.assertIsInstance(core, torch.Tensor)
         self.assertIsInstance(factors, list)
@@ -342,7 +343,7 @@ class TestTensorOps(unittest.TestCase):
         sample_tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         ranks = [2, 3, 3]
 
-        core, factors = TensorOps.tucker_decomposition(sample_tensor, ranks)
+        core, factors = TensorDecompositionOps.tucker_decomposition(sample_tensor, ranks) # Changed here
 
         self.assertIsInstance(core, torch.Tensor)
         self.assertIsInstance(factors, list)
@@ -372,7 +373,7 @@ class TestTensorOps(unittest.TestCase):
         low_rank_matrix_tl = tl.tucker_to_tensor((true_core_np, true_factors_np))
         low_rank_matrix_torch = torch.from_numpy(low_rank_matrix_tl).float()
 
-        core, factors = TensorOps.tucker_decomposition(low_rank_matrix_torch, ranks)
+        core, factors = TensorDecompositionOps.tucker_decomposition(low_rank_matrix_torch, ranks) # Changed here
 
         self.assertIsInstance(core, torch.Tensor)
         self.assertIsInstance(factors, list)
@@ -395,14 +396,14 @@ class TestTensorOps(unittest.TestCase):
         sample_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
         invalid_ranks = [2, 2] # Length 2, tensor ndim 3
         with self.assertRaisesRegex(ValueError, "Length of ranks list .* must match tensor dimensionality"):
-            TensorOps.tucker_decomposition(sample_tensor, invalid_ranks)
+            TensorDecompositionOps.tucker_decomposition(sample_tensor, invalid_ranks) # Changed here
 
     def test_tucker_decomposition_invalid_rank_value_type(self):
         """Test Tucker decomposition with non-integer rank in list."""
         sample_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
         invalid_ranks = [2, 2.5, 2] # type: ignore
         with self.assertRaisesRegex(ValueError, "Ranks must be a list of positive integers"):
-             TensorOps.tucker_decomposition(sample_tensor, invalid_ranks)
+             TensorDecompositionOps.tucker_decomposition(sample_tensor, invalid_ranks) # Changed here
 
 
     def test_tucker_decomposition_invalid_rank_value_zero(self):
@@ -410,22 +411,22 @@ class TestTensorOps(unittest.TestCase):
         sample_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
         invalid_ranks = [2, 0, 2]
         with self.assertRaisesRegex(ValueError, "Ranks must be a list of positive integers"):
-            TensorOps.tucker_decomposition(sample_tensor, invalid_ranks)
+            TensorDecompositionOps.tucker_decomposition(sample_tensor, invalid_ranks) # Changed here
 
     def test_tucker_decomposition_invalid_rank_value_exceeds_dim(self):
         """Test Tucker decomposition with a rank value exceeding tensor dimension."""
         sample_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
         invalid_ranks = [2, 5, 2] # Rank 5 for mode 1 (size 4)
         with self.assertRaisesRegex(ValueError, "Rank for mode 1 .* is out of valid range"):
-            TensorOps.tucker_decomposition(sample_tensor, invalid_ranks)
+            TensorDecompositionOps.tucker_decomposition(sample_tensor, invalid_ranks) # Changed here
 
     def test_tucker_decomposition_type_error(self):
         """Test Tucker decomposition with non-tensor input."""
         with self.assertRaisesRegex(TypeError, "Input at index 0 is not a torch.Tensor"):
-            TensorOps.tucker_decomposition("not a tensor", [2,2]) # type: ignore
+            TensorDecompositionOps.tucker_decomposition("not a tensor", [2,2]) # Changed here; type: ignore
 
         with self.assertRaisesRegex(TypeError, "Input at index 0 is not a torch.Tensor"):
-            TensorOps.tucker_decomposition([1,2,3], [1]) # type: ignore
+            TensorDecompositionOps.tucker_decomposition([1,2,3], [1]) # Changed here; type: ignore
 
     # --- Test HOSVD ---
 
@@ -433,7 +434,7 @@ class TestTensorOps(unittest.TestCase):
         """Test HOSVD on a 3D tensor."""
         sample_tensor = torch.rand(3, 4, 2, dtype=torch.float32) # Using smaller dim for factor construction
 
-        core, factors = TensorOps.hosvd(sample_tensor)
+        core, factors = TensorDecompositionOps.hosvd(sample_tensor) # Changed here
 
         self.assertIsInstance(core, torch.Tensor)
         self.assertIsInstance(factors, list)
@@ -460,7 +461,7 @@ class TestTensorOps(unittest.TestCase):
         """Test HOSVD on a 2D tensor (matrix)."""
         sample_tensor = torch.rand(5, 3, dtype=torch.float32) # Using smaller dim for factor construction
 
-        core, factors = TensorOps.hosvd(sample_tensor)
+        core, factors = TensorDecompositionOps.hosvd(sample_tensor) # Changed here
 
         self.assertIsInstance(core, torch.Tensor)
         self.assertIsInstance(factors, list)
@@ -486,7 +487,7 @@ class TestTensorOps(unittest.TestCase):
     def test_hosvd_type_error(self):
         """Test HOSVD with non-tensor input."""
         with self.assertRaisesRegex(TypeError, "Input at index 0 is not a torch.Tensor"):
-            TensorOps.hosvd("not a tensor") # type: ignore
+            TensorDecompositionOps.hosvd("not a tensor") # Changed here; type: ignore
 
     def test_hosvd_input_tensor_constraints(self):
         """Test HOSVD with 0-dim (scalar) and 1-dim (vector) tensors."""
@@ -494,10 +495,10 @@ class TestTensorOps(unittest.TestCase):
         vector_tensor = torch.rand(7, dtype=torch.float32) # 1-dim
 
         with self.assertRaisesRegex(ValueError, "HOSVD requires a tensor with at least 2 dimensions"):
-            TensorOps.hosvd(scalar_tensor)
+            TensorDecompositionOps.hosvd(scalar_tensor) # Changed here
 
         with self.assertRaisesRegex(ValueError, "HOSVD requires a tensor with at least 2 dimensions"):
-            TensorOps.hosvd(vector_tensor)
+            TensorDecompositionOps.hosvd(vector_tensor) # Changed here
 
     # --- Test TT Decomposition ---
 
@@ -517,7 +518,7 @@ class TestTensorOps(unittest.TestCase):
         low_rank_tensor_tl = tl.tt_to_tensor(true_factors_np)
         low_rank_tensor_torch = torch.from_numpy(low_rank_tensor_tl).float()
 
-        factors = TensorOps.tt_decomposition(low_rank_tensor_torch, rank=internal_ranks)
+        factors = TensorDecompositionOps.tt_decomposition(low_rank_tensor_torch, rank=internal_ranks) # Changed here
 
         self.assertIsInstance(factors, list)
         self.assertEqual(len(factors), low_rank_tensor_torch.ndim)
@@ -540,7 +541,7 @@ class TestTensorOps(unittest.TestCase):
         sample_tensor = torch.rand(3, 4, 2, dtype=torch.float32) # Smaller dimensions
         max_rank = 2
 
-        factors = TensorOps.tt_decomposition(sample_tensor, rank=max_rank)
+        factors = TensorDecompositionOps.tt_decomposition(sample_tensor, rank=max_rank) # Changed here
 
         self.assertIsInstance(factors, list)
         self.assertEqual(len(factors), sample_tensor.ndim)
@@ -578,7 +579,7 @@ class TestTensorOps(unittest.TestCase):
         low_rank_tensor_tl = tl.tt_to_tensor(true_factors_np)
         low_rank_tensor_torch = torch.from_numpy(low_rank_tensor_tl).float()
 
-        factors = TensorOps.tt_decomposition(low_rank_tensor_torch, rank=internal_ranks)
+        factors = TensorDecompositionOps.tt_decomposition(low_rank_tensor_torch, rank=internal_ranks) # Changed here
 
         self.assertIsInstance(factors, list)
         self.assertEqual(len(factors), low_rank_tensor_torch.ndim)
@@ -598,31 +599,31 @@ class TestTensorOps(unittest.TestCase):
         # The implementation of tt_decomposition passes rank=1 (int) to tensor_train for 1D tensors.
         # Based on previous findings, this specific call fails inside TensorLy in the test env.
         with self.assertRaisesRegex(RuntimeError, "TT decomposition failed"):
-            TensorOps.tt_decomposition(tensor_1d, rank=1)
+            TensorDecompositionOps.tt_decomposition(tensor_1d, rank=1) # Changed here
 
         # Also test with user rank = []
         with self.assertRaisesRegex(RuntimeError, "TT decomposition failed"):
-            TensorOps.tt_decomposition(tensor_1d, rank=[])
+            TensorDecompositionOps.tt_decomposition(tensor_1d, rank=[]) # Changed here
 
 
     def test_tt_decomposition_invalid_rank_type(self):
         """Test TT decomposition with invalid rank type."""
         sample_tensor = torch.rand(3,4,5).float()
         with self.assertRaisesRegex(TypeError, "Rank must be an int or a list of ints"):
-            TensorOps.tt_decomposition(sample_tensor, rank="invalid_rank_type") # type: ignore
+            TensorDecompositionOps.tt_decomposition(sample_tensor, rank="invalid_rank_type") # Changed here; type: ignore
 
     def test_tt_decomposition_invalid_rank_list_length(self):
         """Test TT decomposition with incorrect length of rank list for N>1D tensor."""
         sample_tensor = torch.rand(3,4,5).float() # ndim=3, expects N-1=2 internal ranks
         invalid_ranks_list = [2,3,4] # Too long
         with self.assertRaisesRegex(ValueError, "Rank list length must be tensor.ndim - 1"):
-            TensorOps.tt_decomposition(sample_tensor, rank=invalid_ranks_list)
+            TensorDecompositionOps.tt_decomposition(sample_tensor, rank=invalid_ranks_list) # Changed here
 
         # Test for 1D tensor where rank list must be empty
         tensor_1d = torch.rand(5).float()
         invalid_ranks_for_1d = [1] # Should be empty list for user input to mean default rank=1
         with self.assertRaisesRegex(ValueError, "For a 1D tensor, rank list must be empty for user input"):
-             TensorOps.tt_decomposition(tensor_1d, rank=invalid_ranks_for_1d)
+             TensorDecompositionOps.tt_decomposition(tensor_1d, rank=invalid_ranks_for_1d) # Changed here
 
 
     def test_tt_decomposition_invalid_rank_list_values(self):
@@ -630,25 +631,25 @@ class TestTensorOps(unittest.TestCase):
         sample_tensor = torch.rand(3,4,5).float()
         invalid_ranks_list = [2, 0] # Zero rank
         with self.assertRaisesRegex(ValueError, "All ranks in the list must be positive integers"):
-            TensorOps.tt_decomposition(sample_tensor, rank=invalid_ranks_list)
+            TensorDecompositionOps.tt_decomposition(sample_tensor, rank=invalid_ranks_list) # Changed here
 
     def test_tt_decomposition_invalid_rank_int_value(self):
         """Test TT decomposition with non-positive integer rank."""
         sample_tensor = torch.rand(3,4,5).float()
         invalid_rank_int = 0
         with self.assertRaisesRegex(ValueError, "If rank is an integer, it must be positive"):
-            TensorOps.tt_decomposition(sample_tensor, rank=invalid_rank_int)
+            TensorDecompositionOps.tt_decomposition(sample_tensor, rank=invalid_rank_int) # Changed here
 
     def test_tt_decomposition_invalid_tensor_ndim0(self):
         """Test TT decomposition with a 0-dimensional (scalar) tensor."""
         scalar_tensor = torch.tensor(1.0).float()
         with self.assertRaisesRegex(ValueError, "TT decomposition requires a tensor with at least 1 dimension"):
-            TensorOps.tt_decomposition(scalar_tensor, rank=1)
+            TensorDecompositionOps.tt_decomposition(scalar_tensor, rank=1) # Changed here
 
     def test_tt_decomposition_type_error_tensor(self):
         """Test TT decomposition with non-tensor input."""
         with self.assertRaisesRegex(TypeError, "Input at index 0 is not a torch.Tensor"):
-            TensorOps.tt_decomposition("not a tensor", rank=1) # type: ignore
+            TensorDecompositionOps.tt_decomposition("not a tensor", rank=1) # Changed here; type: ignore
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit includes a major refactoring to separate tensor decomposition operations into a new module and continues with the implementation of new decomposition methods.

Refactoring:
- Created `tensorus/tensor_decompositions.py` containing a new `TensorDecompositionOps` class.
- Moved CP, Tucker, HOSVD, and Tensor Train (TT) decomposition methods from `TensorOps` (in `tensorus/tensor_ops.py`) into `TensorDecompositionOps`.
- Updated all associated unit tests in `tests/test_tensor_ops.py` to reflect these changes, ensuring they call methods from the new location.
- Updated `if __name__ == '__main__'` blocks:
    - `tensorus/tensor_ops.py` examples were cleaned up.
    - `tensorus/tensor_decompositions.py` now includes runnable examples for all moved decomposition methods (CP, Tucker, HOSVD, TT).

New Implementation:
- Tensor Ring (TR) Decomposition:
  - Added `tr_decomposition` method to `TensorDecompositionOps`.
  - Includes input validation and rank parameter handling adapted for the execution environment's TensorLy version.
  - Added an example for TR decomposition to the main execution block of `tensorus/tensor_decompositions.py`, including reconstruction.

Progress Notes:
- Implementations for TT and TR decompositions include adaptations for the specific rank parameter formats expected by the TensorLy version in the execution environment.
- A known issue where TT decomposition for 1D tensors fails within the environment's TensorLy has been noted and handled in examples/tests.

Next, I will add unit tests for the TR decomposition.