### PR TITLE
Fix TensorStorage API and reduce import requirements

### DIFF
--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -1,7 +1,7 @@
 # api.py
 
 import logging
-from typing import List, Dict, Any, Optional, Tuple, Union, Callable, Awaitable
+from typing import List, Dict, Any, Optional, Tuple, Union, Callable, Awaitable, TYPE_CHECKING
 import random  # For simulating logs/status
 import time  # For simulating timestamps
 import math  # For simulating metrics
@@ -90,7 +90,6 @@ async def add_security_headers(request: Request, call_next):
 try:
     from .tensor_storage import TensorStorage
     from .nql_agent import NQLAgent
-    from .ingestion_agent import DataIngestionAgent # Added import
     from .tensor_ops import TensorOps
     # from rl_agent import RLAgent
     # from automl_agent import AutoMLAgent
@@ -99,6 +98,10 @@ except ImportError as e:
     print("Please ensure tensor_storage.py, nql_agent.py, and tensor_ops.py are in the Python path.")
     # Optionally raise the error or exit if these are critical at startup
     raise
+
+if TYPE_CHECKING:
+    # Import for type checking only to avoid heavy dependency during runtime
+    from .ingestion_agent import DataIngestionAgent
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -161,13 +164,14 @@ agent_registry = {
      },
 }
 
-live_agents: Dict[str, DataIngestionAgent] = {} # Stores live agent instances, key is agent_id
+live_agents: Dict[str, "DataIngestionAgent"] = {}  # Stores live agent instances, key is agent_id
 
-def _get_or_create_ingestion_agent() -> DataIngestionAgent:
+def _get_or_create_ingestion_agent() -> "DataIngestionAgent":
     """
     Retrieves the existing DataIngestionAgent instance or creates a new one
     if it doesn't exist. Ensures its source directory is created.
     """
+    from .ingestion_agent import DataIngestionAgent
     global live_agents
     if "ingestion" not in live_agents:
         if "ingestion" not in agent_registry:

--- a/tensorus/tensor_storage.py
+++ b/tensorus/tensor_storage.py
@@ -116,6 +116,10 @@ class TensorStorage:
         logging.info(f"Available datasets: {dataset_names}")
         return dataset_names
 
+    def dataset_exists(self, name: str) -> bool:
+        """Check if a dataset with the given name exists."""
+        return name in self.datasets
+
     def create_dataset(self, name: str) -> None:
         """
         Creates a new, empty dataset.


### PR DESCRIPTION
## Summary
- avoid heavy torchvision dependency by importing `DataIngestionAgent` lazily
- expose new `dataset_exists` helper on `TensorStorage`

## Testing
- `pytest tests/test_tensor_operations.py::TestNumPyTensorOperations::test_matrix_covariance -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe20e45a08331acdc8828f4b0986b