### PR TITLE
Add dataset_exists helper to TensorStorage

### DIFF
--- a/tensorus/tensor_storage.py
+++ b/tensorus/tensor_storage.py
@@ -116,6 +116,15 @@ class TensorStorage:
         logging.info(f"Available datasets: {dataset_names}")
         return dataset_names
 
+    def dataset_exists(self, name: str) -> bool:
+        """Check whether a dataset exists either in memory or on disk."""
+        if name in self.datasets:
+            return True
+        if self.storage_path:
+            file_path = self.storage_path / f"{name}.pt"
+            return file_path.exists()
+        return False
+
     def create_dataset(self, name: str) -> None:
         """
         Creates a new, empty dataset.


### PR DESCRIPTION
## Summary
- add `dataset_exists()` to TensorStorage so API and tests can check dataset presence

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683fe20227288331acc989fb75cb40e9