### PR TITLE
Implement std tensor operation

### DIFF
--- a/tensorus/tensor_ops.py
+++ b/tensorus/tensor_ops.py
@@ -429,6 +429,13 @@ class TensorOps:
         return torch.var(tensor.float(), dim=dim, unbiased=unbiased, keepdim=keepdim)
 
     @staticmethod
+    def std(tensor: torch.Tensor, dim: Optional[Union[int, Tuple[int, ...]]] = None,
+            unbiased: bool = False, keepdim: bool = False) -> torch.Tensor:
+        """Standard deviation of tensor elements."""
+        TensorOps._check_tensor(tensor)
+        return torch.std(tensor.float(), dim=dim, unbiased=unbiased, keepdim=keepdim)
+
+    @staticmethod
     def covariance(matrix_X: torch.Tensor, matrix_Y: Optional[torch.Tensor] = None,
                    rowvar: bool = True, bias: bool = False, ddof: Optional[int] = None) -> torch.Tensor:
         """Estimate covariance matrix of the given variables."""

--- a/tests/test_tensor_ops.py
+++ b/tests/test_tensor_ops.py
@@ -249,6 +249,22 @@ class TestTensorOps(unittest.TestCase):
         self.assertTrue(torch.allclose(TensorOps.frobenius_norm(t), torch.linalg.norm(t, "fro")))
         self.assertTrue(torch.allclose(TensorOps.l1_norm(t), torch.sum(torch.abs(t))))
 
+    def test_std_default(self):
+        t = torch.tensor([[1., 2.], [3., 4.]])
+        expected = torch.std(t, unbiased=False)
+        result = TensorOps.std(t)
+        self.assertTrue(torch.allclose(result, expected))
+
+    def test_std_dim_unbiased_keepdim(self):
+        t = torch.tensor([[1., 2.], [3., 4.]])
+        expected = torch.std(t, dim=0, unbiased=True, keepdim=True)
+        result = TensorOps.std(t, dim=0, unbiased=True, keepdim=True)
+        self.assertTrue(torch.allclose(result, expected))
+
+    def test_std_type_error(self):
+        with self.assertRaises(TypeError):
+            TensorOps.std("not_a_tensor")  # type: ignore
+
     # --- Test CP Decomposition ---
 
     def test_cp_decomposition_valid_low_rank(self):


### PR DESCRIPTION
## Summary
- add `TensorOps.std` for computing standard deviation
- test standard deviation operation and TypeError handling

## Testing
- `pytest -q` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6840059e5d4083319618027905a562de