### PR TITLE
Add norm utilities

### DIFF
--- a/tensorus/tensor_ops.py
+++ b/tensorus/tensor_ops.py
@@ -476,3 +476,29 @@ class TensorOps:
         TensorOps._check_tensor(tensor)
         return torch.sum(torch.abs(tensor))
 
+    @staticmethod
+    def l2_norm(tensor: torch.Tensor) -> torch.Tensor:
+        """L2 norm of a tensor."""
+        TensorOps._check_tensor(tensor)
+        return torch.linalg.norm(tensor, 2)
+
+    @staticmethod
+    def p_norm(tensor: torch.Tensor, p: float) -> torch.Tensor:
+        """General p-norm of a tensor."""
+        TensorOps._check_tensor(tensor)
+        if not isinstance(p, (int, float)):
+            raise TypeError("p must be a numeric value")
+        if p <= 0:
+            raise ValueError("p must be positive")
+        return torch.linalg.norm(tensor, p)
+
+    @staticmethod
+    def nuclear_norm(matrix: torch.Tensor) -> torch.Tensor:
+        """Nuclear norm (sum of singular values) for a 2-D tensor."""
+        TensorOps._check_tensor(matrix)
+        if matrix.ndim != 2:
+            raise ValueError(
+                f"Nuclear norm expects a 2-D tensor, got shape {matrix.shape}"
+            )
+        return torch.linalg.matrix_norm(matrix, ord="nuc")
+

--- a/tests/test_tensor_ops.py
+++ b/tests/test_tensor_ops.py
@@ -248,6 +248,12 @@ class TestTensorOps(unittest.TestCase):
         self.assertTrue(torch.allclose(corr, expected_corr))
         self.assertTrue(torch.allclose(TensorOps.frobenius_norm(t), torch.linalg.norm(t, "fro")))
         self.assertTrue(torch.allclose(TensorOps.l1_norm(t), torch.sum(torch.abs(t))))
+        self.assertTrue(torch.allclose(TensorOps.l2_norm(t), torch.linalg.norm(t, 2)))
+        self.assertTrue(torch.allclose(TensorOps.p_norm(t, 3), torch.linalg.norm(t, 3)))
+        m = torch.tensor([[1., 2.], [3., 4.]])
+        self.assertTrue(torch.allclose(TensorOps.nuclear_norm(m), torch.linalg.matrix_norm(m, ord="nuc")))
+        with self.assertRaises(ValueError):
+            TensorOps.nuclear_norm(torch.tensor([1., 2., 3.]))
 
     def test_std_default(self):
         t = torch.tensor([[1., 2.], [3., 4.]])


### PR DESCRIPTION
## Summary
- add `l2_norm`, `p_norm`, and `nuclear_norm` helpers
- validate dimension and parameters
- test the new norm utilities on small tensors

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6840076df7f08331a7689e94c082e9bf