### PR TITLE
Add flatten, squeeze and unsqueeze ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,9 @@ This section details the core tensor manipulation functionalities provided by `t
 *   `reshape(tensor, shape)`: Changes the shape of a tensor without changing its data.
 *   `transpose(tensor, dim0, dim1)`: Swaps two dimensions of a tensor.
 *   `permute(tensor, dims)`: Permutes the dimensions of a tensor according to the specified order.
+*   `flatten(tensor, start_dim=0, end_dim=-1)`: Flattens a range of dimensions into a single dimension.
+*   `squeeze(tensor, dim=None)`: Removes dimensions of size 1, or a specific dimension if provided.
+*   `unsqueeze(tensor, dim)`: Inserts a dimension of size 1 at the given position.
 
 #### Concatenation and Splitting
 

--- a/tensorus/tensor_ops.py
+++ b/tensorus/tensor_ops.py
@@ -280,6 +280,52 @@ class TensorOps:
             logging.error(f"Error during permute: {e}. tensor shape: {tensor.shape}, dims: {dims}")
             raise e
 
+    @staticmethod
+    def flatten(tensor: torch.Tensor, start_dim: int = 0, end_dim: int = -1) -> torch.Tensor:
+        """Flatten contiguous dimensions of a tensor."""
+        TensorOps._check_tensor(tensor)
+        rank = tensor.ndim
+        # Normalize negative indices
+        if start_dim < 0:
+            start_dim += rank
+        if end_dim < 0:
+            end_dim += rank
+        if not (0 <= start_dim < rank) or not (0 <= end_dim < rank):
+            raise ValueError(f"start_dim and end_dim must be in [0, {rank-1}], got {start_dim} and {end_dim}")
+        if start_dim > end_dim:
+            raise ValueError(f"start_dim ({start_dim}) cannot be greater than end_dim ({end_dim})")
+        try:
+            return torch.flatten(tensor, start_dim=start_dim, end_dim=end_dim)
+        except Exception as e:
+            logging.error(f"Error during flatten: {e}. tensor shape: {tensor.shape}, start_dim: {start_dim}, end_dim: {end_dim}")
+            raise e
+
+    @staticmethod
+    def squeeze(tensor: torch.Tensor, dim: Optional[int] = None) -> torch.Tensor:
+        """Remove dimensions of size 1."""
+        TensorOps._check_tensor(tensor)
+        if dim is not None:
+            if dim < -tensor.ndim or dim >= tensor.ndim:
+                raise ValueError(f"dim {dim} out of range for tensor with rank {tensor.ndim}")
+        try:
+            return torch.squeeze(tensor, dim) if dim is not None else torch.squeeze(tensor)
+        except Exception as e:
+            logging.error(f"Error during squeeze: {e}. tensor shape: {tensor.shape}, dim: {dim}")
+            raise e
+
+    @staticmethod
+    def unsqueeze(tensor: torch.Tensor, dim: int) -> torch.Tensor:
+        """Insert a dimension of size 1 at the specified position."""
+        TensorOps._check_tensor(tensor)
+        rank = tensor.ndim
+        if dim < -(rank + 1) or dim > rank:
+            raise ValueError(f"dim {dim} out of valid range [-(rank+1), rank] for tensor rank {rank}")
+        try:
+            return torch.unsqueeze(tensor, dim)
+        except Exception as e:
+            logging.error(f"Error during unsqueeze: {e}. tensor shape: {tensor.shape}, dim: {dim}")
+            raise e
+
 
     # --- Concatenation and Splitting ---
 

--- a/tests/test_tensor_ops.py
+++ b/tests/test_tensor_ops.py
@@ -271,6 +271,41 @@ class TestTensorOps(unittest.TestCase):
         with self.assertRaises(TypeError):
             TensorOps.std("not_a_tensor")  # type: ignore
 
+    # --- Test Reshaping Operations ---
+    def test_flatten_default(self):
+        t = torch.arange(6).reshape(2, 3)
+        expected = torch.flatten(t)
+        result = TensorOps.flatten(t)
+        self.assertTrue(torch.equal(result, expected))
+
+    def test_flatten_start_end(self):
+        t = torch.arange(24).reshape(2, 3, 4)
+        expected = torch.flatten(t, start_dim=1, end_dim=2)
+        result = TensorOps.flatten(t, start_dim=1, end_dim=2)
+        self.assertTrue(torch.equal(result, expected))
+        self.assertEqual(result.shape, (2, 12))
+
+    def test_squeeze_default(self):
+        t = torch.zeros(1, 3, 1, 4)
+        expected = torch.squeeze(t)
+        result = TensorOps.squeeze(t)
+        self.assertTrue(torch.equal(result, expected))
+        self.assertEqual(result.shape, (3, 4))
+
+    def test_squeeze_dim(self):
+        t = torch.zeros(1, 3, 1, 4)
+        expected = torch.squeeze(t, dim=2)
+        result = TensorOps.squeeze(t, dim=2)
+        self.assertTrue(torch.equal(result, expected))
+        self.assertEqual(result.shape, (1, 3, 4))
+
+    def test_unsqueeze(self):
+        t = torch.randn(3, 4)
+        expected = torch.unsqueeze(t, dim=0)
+        result = TensorOps.unsqueeze(t, dim=0)
+        self.assertTrue(torch.equal(result, expected))
+        self.assertEqual(result.shape, (1, 3, 4))
+
     # --- Test CP Decomposition ---
 
     def test_cp_decomposition_valid_low_rank(self):


### PR DESCRIPTION
## Summary
- extend TensorOps with flatten, squeeze and unsqueeze
- document new ops in README
- test reshaping behaviour

## Testing
- `pytest tests/test_tensor_ops.py::TestTensorOps::test_flatten_default -q`
- `pytest tests/test_tensor_ops.py::TestTensorOps::test_flatten_start_end tests/test_tensor_ops.py::TestTensorOps::test_squeeze_default tests/test_tensor_ops.py::TestTensorOps::test_squeeze_dim tests/test_tensor_ops.py::TestTensorOps::test_unsqueeze -q`


------
https://chatgpt.com/codex/tasks/task_e_684008e77d008331996f50e47b860804