### PR TITLE
Add 3D convolution function

### DIFF
--- a/tensorus/tensor_ops.py
+++ b/tensorus/tensor_ops.py
@@ -506,6 +506,33 @@ class TensorOps:
         result = F.conv2d(img, ker, padding=padding)
         return result.squeeze(0).squeeze(0)
 
+    @staticmethod
+    def convolve_3d(volume: torch.Tensor, kernel: torch.Tensor, mode: str = "valid") -> torch.Tensor:
+        """3D convolution implemented with `torch.nn.functional.conv3d`."""
+        import torch.nn.functional as F
+        TensorOps._check_tensor(volume, kernel)
+        if volume.ndim != 3 or kernel.ndim != 3:
+            raise ValueError("Inputs must be 3D tensors")
+
+        vol = volume.unsqueeze(0).unsqueeze(0)
+        ker = kernel.flip(0, 1, 2).unsqueeze(0).unsqueeze(0)
+
+        if mode == "full":
+            padding = (kernel.shape[0] - 1,
+                       kernel.shape[1] - 1,
+                       kernel.shape[2] - 1)
+        elif mode == "same":
+            padding = (kernel.shape[0] // 2,
+                       kernel.shape[1] // 2,
+                       kernel.shape[2] // 2)
+        elif mode == "valid":
+            padding = (0, 0, 0)
+        else:
+            raise ValueError("mode must be one of 'full', 'same', or 'valid'")
+
+        result = F.conv3d(vol, ker, padding=padding)
+        return result.squeeze(0).squeeze(0)
+
     # --- Statistical Operations ---
 
     @staticmethod

--- a/tests/test_tensor_ops.py
+++ b/tests/test_tensor_ops.py
@@ -262,6 +262,20 @@ class TestTensorOps(unittest.TestCase):
         conv2d_same = TensorOps.convolve_2d(img, k, mode="same")
         self.assertEqual(conv2d_same.shape, img.shape)
 
+    def test_convolve_3d(self):
+        vol = torch.arange(27.).reshape(3, 3, 3)
+        ker = torch.ones((2, 2, 2))
+        expected = torch.nn.functional.conv3d(
+            vol.unsqueeze(0).unsqueeze(0),
+            ker.flip(0, 1, 2).unsqueeze(0).unsqueeze(0),
+        ).squeeze(0).squeeze(0)
+        result = TensorOps.convolve_3d(vol, ker, mode="valid")
+        self.assertTrue(torch.allclose(result, expected))
+
+        ker_same = torch.ones((3, 3, 3))
+        conv_same = TensorOps.convolve_3d(vol, ker_same, mode="same")
+        self.assertEqual(conv_same.shape, vol.shape)
+
     def test_statistics(self):
         t = torch.tensor([[1., 2.], [3., 4.]])
         self.assertTrue(torch.allclose(TensorOps.variance(t), torch.var(t, unbiased=False)))


### PR DESCRIPTION
## Summary
- implement `convolve_3d` in tensor_ops using `torch.nn.functional.conv3d`
- extend unit tests with coverage for 3D convolution

## Testing
- `pytest tests/test_tensor_ops.py::TestTensorOps::test_convolve_3d -q`

------
https://chatgpt.com/codex/tasks/task_e_68400cad4458833192ba20c62ab9ef85