### PR TITLE
Add linear algebra helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,13 @@ This section details the core tensor manipulation functionalities provided by `t
 *   `matrix_eigendecomposition(matrix_A)`: Returns eigenvalues and eigenvectors of a square matrix.
 *   `matrix_trace(matrix_A)`: Computes the trace of a 2-D matrix.
 *   `tensor_trace(tensor_A, axis1=0, axis2=1)`: Trace of a tensor along two axes.
+*   `svd(matrix)`: Singular value decomposition of a matrix, returns `U`, `S`, and `Vh`.
+*   `qr_decomposition(matrix)`: QR decomposition returning `Q` and `R`.
+*   `lu_decomposition(matrix)`: LU decomposition returning permutation `P`, lower `L`, and upper `U` matrices.
+*   `cholesky_decomposition(matrix)`: Cholesky factor of a symmetric positive-definite matrix.
+*   `matrix_inverse(matrix)`: Inverse of a square matrix.
+*   `matrix_determinant(matrix)`: Determinant of a square matrix.
+*   `matrix_rank(matrix)`: Rank of a matrix.
 
 #### Reduction Operations
 

--- a/tensorus/tensor_ops.py
+++ b/tensorus/tensor_ops.py
@@ -464,6 +464,70 @@ class TensorOps:
             raise ValueError("Dimensions for axis1 and axis2 must match")
         return torch.diagonal(tensor_A, offset=0, dim1=axis1, dim2=axis2).sum(-1)
 
+    @staticmethod
+    def svd(matrix: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Singular Value Decomposition of a 2-D matrix."""
+        TensorOps._check_tensor(matrix)
+        if matrix.ndim != 2:
+            raise ValueError("Input matrix must be 2-D")
+        return torch.linalg.svd(matrix, full_matrices=False)
+
+    @staticmethod
+    def qr_decomposition(matrix: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """QR decomposition of a 2-D matrix."""
+        TensorOps._check_tensor(matrix)
+        if matrix.ndim != 2:
+            raise ValueError("Input matrix must be 2-D")
+        return torch.linalg.qr(matrix)
+
+    @staticmethod
+    def lu_decomposition(matrix: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """LU decomposition of a 2-D matrix returning P, L, U."""
+        TensorOps._check_tensor(matrix)
+        if matrix.ndim != 2:
+            raise ValueError("Input matrix must be 2-D")
+        return torch.linalg.lu(matrix)
+
+    @staticmethod
+    def cholesky_decomposition(matrix: torch.Tensor) -> torch.Tensor:
+        """Cholesky decomposition of a symmetric positive-definite matrix."""
+        TensorOps._check_tensor(matrix)
+        if matrix.ndim != 2:
+            raise ValueError("Input matrix must be 2-D")
+        if matrix.shape[0] != matrix.shape[1]:
+            raise ValueError("Input matrix must be square")
+        if not torch.allclose(matrix, matrix.transpose(-2, -1)):
+            raise ValueError("Input matrix must be symmetric")
+        return torch.linalg.cholesky(matrix)
+
+    @staticmethod
+    def matrix_inverse(matrix: torch.Tensor) -> torch.Tensor:
+        """Inverse of a square matrix."""
+        TensorOps._check_tensor(matrix)
+        if matrix.ndim != 2:
+            raise ValueError("Input matrix must be 2-D")
+        if matrix.shape[0] != matrix.shape[1]:
+            raise ValueError("Input matrix must be square")
+        return torch.linalg.inv(matrix)
+
+    @staticmethod
+    def matrix_determinant(matrix: torch.Tensor) -> torch.Tensor:
+        """Determinant of a square matrix."""
+        TensorOps._check_tensor(matrix)
+        if matrix.ndim != 2:
+            raise ValueError("Input matrix must be 2-D")
+        if matrix.shape[0] != matrix.shape[1]:
+            raise ValueError("Input matrix must be square")
+        return torch.linalg.det(matrix)
+
+    @staticmethod
+    def matrix_rank(matrix: torch.Tensor) -> torch.Tensor:
+        """Matrix rank of a 2-D tensor."""
+        TensorOps._check_tensor(matrix)
+        if matrix.ndim != 2:
+            raise ValueError("Input matrix must be 2-D")
+        return torch.linalg.matrix_rank(matrix)
+
     # --- Convolution Operations ---
 
     @staticmethod

--- a/tests/test_tensor_ops.py
+++ b/tests/test_tensor_ops.py
@@ -251,6 +251,50 @@ class TestTensorOps(unittest.TestCase):
         expected = torch.tensor([0.+9.+18., 1.+10.+19., 2.+11.+20., 3.+12.+21.])
         self.assertTrue(torch.allclose(trace_res, expected))
 
+    def test_svd_reconstruction(self):
+        A = torch.tensor([[3., 1.], [1., 3.]], dtype=torch.float32)
+        U, S, Vh = TensorOps.svd(A)
+        reconstructed = U @ torch.diag(S) @ Vh
+        self.assertTrue(torch.allclose(reconstructed, A))
+
+    def test_qr_reconstruction(self):
+        A = torch.randn(4, 3)
+        Q, R = TensorOps.qr_decomposition(A)
+        self.assertTrue(torch.allclose(Q @ R, A))
+
+    def test_lu_decomposition(self):
+        A = torch.tensor([[4., 3.], [6., 3.]], dtype=torch.float32)
+        P, L, U = TensorOps.lu_decomposition(A)
+        self.assertTrue(torch.allclose(P @ A, L @ U))
+
+    def test_cholesky_valid(self):
+        B = torch.tensor([[2., 0.], [1., 1.]], dtype=torch.float32)
+        A = B @ B.t()
+        L = TensorOps.cholesky_decomposition(A)
+        self.assertTrue(torch.allclose(L @ L.t(), A))
+
+    def test_cholesky_non_symmetric_error(self):
+        A = torch.tensor([[1., 2.], [3., 4.]], dtype=torch.float32)
+        with self.assertRaises(ValueError):
+            TensorOps.cholesky_decomposition(A)
+
+    def test_matrix_inverse(self):
+        A = torch.tensor([[4., 7.], [2., 6.]], dtype=torch.float32)
+        inv = TensorOps.matrix_inverse(A)
+        self.assertTrue(torch.allclose(A @ inv, torch.eye(2)))
+
+    def test_matrix_inverse_non_square_error(self):
+        A = torch.randn(2, 3)
+        with self.assertRaises(ValueError):
+            TensorOps.matrix_inverse(A)
+
+    def test_matrix_determinant_and_rank(self):
+        A = torch.tensor([[1., 2.], [2., 4.]], dtype=torch.float32)
+        det = TensorOps.matrix_determinant(A)
+        rank = TensorOps.matrix_rank(A)
+        self.assertEqual(det.item(), 0.0)
+        self.assertEqual(rank.item(), 1)
+
     def test_convolutions(self):
         sig = torch.tensor([1., 2., 3.])
         ker = torch.tensor([1., 1.])


### PR DESCRIPTION
## Summary
- add linear algebra helper methods to `TensorOps`
- document them in README
- test SVD, QR, LU, Cholesky, inverse, determinant and rank helpers

## Testing
- `pip install torch torchvision numpy tensorly Pillow fastapi pydantic uvicorn[standard] streamlit requests plotly matplotlib statsmodels` *(fails: Package(s) not found: torch)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68400dbf39fc8331bb647d81e70838cd