### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,14 @@ graph TD
     venv\Scripts\activate  # On Windows
     ```
 
-3.  Install dependencies:
+3.  Install dependencies using the provided setup script:
 
     ```bash
-    pip install -r requirements.txt
+    ./setup.sh
     ```
+    This installs Python requirements from `requirements.txt` and
+    `requirements-test.txt` and runs `npm install` in
+    `mcp_tensorus_server` (needed for integration tests).
 
 ### Running the API Server
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Setup script for Tensorus development environment
+set -e
+
+# Install Python dependencies
+pip install -r requirements.txt
+pip install -r requirements-test.txt
+
+# Install Node.js dependencies for the MCP server (used in integration tests)
+pushd mcp_tensorus_server
+npm install
+popd


### PR DESCRIPTION
## Summary
- add a `setup.sh` script for installing Python and Node dependencies
- document using this script in the README

## Testing
- `./setup.sh` *(fails: Could not find a version that satisfies the requirement h-tucker)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `npm test` in `mcp_tensorus_server` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402c6543fc83318df426c2b78a571e