### PR TITLE
Update setup workflow and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ graph TD
     ./setup.sh
     ```
     This installs Python requirements from `requirements.txt` and
-    `requirements-test.txt` and runs `npm install` in
-    `mcp_tensorus_server` (needed for integration tests).
+    `requirements-test.txt`, using CPU wheels for PyTorch and
+    pinning `httpx` to a compatible version. The script also runs
+    `npm install` in `mcp_tensorus_server` (needed for integration tests).
 
 ### Running the API Server
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,5 @@
 
 pytest
 pytest-asyncio
-httpx
+httpx==0.23.0
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ torch>=1.13.0
 torchvision>=0.14.0
 numpy>=1.21.0
 tensorly
-h-tucker
 
 # --- Agent Specific Dependencies ---
 # For Ingestion Agent image processing example

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@
 set -e
 
 # Install Python dependencies
+pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
 pip install -r requirements.txt
 pip install -r requirements-test.txt
 


### PR DESCRIPTION
## Summary
- install CPU builds of PyTorch in `setup.sh`
- drop unavailable `h-tucker` package
- pin `httpx` in test requirements
- document the setup change in README

## Testing
- `./setup.sh`
- `PYTHONPATH=$PWD pytest tests/test_tensor_ops.py::TestTensorOps::test_add_tensor_tensor -q`


------
https://chatgpt.com/codex/tasks/task_e_6840273e2db4833189b2b9afb8e76b4d