### PR TITLE
Add TensorStorage model helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,26 @@ The Streamlit UI provides a user-friendly interface for:
     *   `task_type`: Type of task ('regression' or 'classification').
     *   `results_dataset`: Dataset name for storing results.
 
+### Model Utilities
+
+`tensorus.models.utils` provides small helpers for working with datasets in
+`TensorStorage` when training models.  The snippet below loads features and
+targets and stores predictions back into the storage:
+
+```python
+from tensorus.tensor_storage import TensorStorage
+from tensorus.models.linear_regression import LinearRegressionModel
+from tensorus.models.utils import load_xy_from_storage, store_predictions
+
+storage = TensorStorage()
+X, y = load_xy_from_storage(storage, "my_dataset", target_field="label")
+model = LinearRegressionModel()
+model.fit(X, y)
+preds = model.predict(X)
+store_predictions(storage, "my_predictions", preds,
+                  model_name="LinearRegressionModel")
+```
+
 ## Basic Tensor Operations
 
 This section details the core tensor manipulation functionalities provided by `tensor_ops.py`. These operations are designed to be robust, with built-in type and shape checking where appropriate.

--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -4,6 +4,7 @@ from .base import TensorusModel
 from .registry import register_model, get_model
 from .linear_regression import LinearRegressionModel
 from .logistic_regression import LogisticRegressionModel
+from .utils import load_xy_from_storage, store_predictions
 
 __all__ = [
     "TensorusModel",
@@ -11,4 +12,6 @@ __all__ = [
     "get_model",
     "LinearRegressionModel",
     "LogisticRegressionModel",
+    "load_xy_from_storage",
+    "store_predictions",
 ]

--- a/tensorus/models/utils.py
+++ b/tensorus/models/utils.py
@@ -1,0 +1,112 @@
+"""Utilities for loading data and storing predictions in TensorStorage.
+
+This module contains convenience helpers for common workflows when training
+models using data stored in :class:`~tensorus.tensor_storage.TensorStorage`.
+
+Example
+-------
+>>> from tensorus.tensor_storage import TensorStorage
+>>> from tensorus.models.linear_regression import LinearRegressionModel
+>>> from tensorus.models.utils import load_xy_from_storage, store_predictions
+>>>
+>>> storage = TensorStorage()
+>>> # assume 'train_ds' contains feature tensors with metadata {'label': int}
+>>> X, y = load_xy_from_storage(storage, 'train_ds', target_field='label')
+>>> model = LinearRegressionModel()
+>>> model.fit(X, y)
+>>> preds = model.predict(X)
+>>> store_predictions(storage, 'train_predictions', preds,
+...                   model_name='LinearRegressionModel')
+"""
+
+from typing import Tuple, Any, Dict, Optional
+import logging
+import torch
+
+from ..tensor_storage import TensorStorage
+
+logger = logging.getLogger(__name__)
+
+
+def load_xy_from_storage(
+    storage: TensorStorage,
+    dataset_name: str,
+    target_field: str = "y",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Load feature and target tensors from a dataset.
+
+    The dataset should store one tensor per sample. Each tensor's metadata must
+    contain the target value under ``target_field``. All tensors are stacked into
+    a single feature matrix ``X`` and the targets are returned as a 1-D tensor
+    ``y``.
+
+    Parameters
+    ----------
+    storage:
+        The :class:`TensorStorage` instance to load from.
+    dataset_name:
+        Name of the dataset containing the records.
+    target_field:
+        Metadata key that holds the target value for each record.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(X, y)`` where ``X`` has shape ``(n_samples, ...)`` and ``y`` has shape
+        ``(n_samples,)``.
+    """
+    records = storage.get_dataset_with_metadata(dataset_name)
+    features = []
+    targets = []
+    for rec in records:
+        tensor = rec["tensor"]
+        meta = rec["metadata"]
+        if target_field not in meta:
+            raise ValueError(f"Record missing target field '{target_field}'")
+        features.append(tensor)
+        targets.append(meta[target_field])
+
+    X = torch.stack([t.float() for t in features]) if features else torch.empty(0)
+    y = torch.tensor(targets, dtype=torch.float32) if targets else torch.empty(0)
+    logger.info(
+        "Loaded dataset '%s' with %d samples from TensorStorage", dataset_name, len(features)
+    )
+    return X, y
+
+
+def store_predictions(
+    storage: TensorStorage,
+    dataset_name: str,
+    predictions: torch.Tensor,
+    model_name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Store prediction tensor into ``TensorStorage``.
+
+    Parameters
+    ----------
+    storage:
+        Destination :class:`TensorStorage`.
+    dataset_name:
+        Dataset name to insert into (created if missing).
+    predictions:
+        Tensor of model predictions.
+    model_name:
+        Identifier of the model that produced the predictions.
+    metadata:
+        Optional additional metadata to store alongside the tensor.
+
+    Returns
+    -------
+    str
+        Record ID of the stored prediction tensor.
+    """
+    if dataset_name not in storage.list_datasets():
+        storage.create_dataset(dataset_name)
+    meta = metadata.copy() if metadata else {}
+    meta.update({"model_name": model_name, "created_by": "store_predictions"})
+    record_id = storage.insert(dataset_name, predictions.cpu(), meta)
+    logger.info(
+        "Stored predictions in dataset '%s' with record_id '%s'", dataset_name, record_id
+    )
+    return record_id


### PR DESCRIPTION
## Summary
- add `load_xy_from_storage` and `store_predictions` helpers
- expose helpers in `tensorus.models` package
- document model utilities in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & long run)*
- `npm run test:integration` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840635558488331b4a32df2526b539a