### PR TITLE
Add PCA and tSNE models

### DIFF
--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -13,6 +13,8 @@ from .kmeans import KMeansClusteringModel
 from .knn_classifier import KNNClassifierModel
 from .random_forest_classifier import RandomForestClassifierModel
 from .random_forest_regressor import RandomForestRegressorModel
+from .pca_decomposition import PCADecompositionModel
+from .tsne_embedding import TSNEEmbeddingModel
 from .utils import load_xy_from_storage, store_predictions
 
 __all__ = [
@@ -30,6 +32,8 @@ __all__ = [
     "KNNClassifierModel",
     "RandomForestClassifierModel",
     "RandomForestRegressorModel",
+    "PCADecompositionModel",
+    "TSNEEmbeddingModel",
     "load_xy_from_storage",
     "store_predictions",
 ]

--- a/tensorus/models/pca_decomposition.py
+++ b/tensorus/models/pca_decomposition.py
@@ -1,0 +1,55 @@
+import numpy as np
+from typing import Any, Optional
+from sklearn.decomposition import PCA
+import joblib
+
+from .base import TensorusModel
+
+
+class PCADecompositionModel(TensorusModel):
+    """Principal Component Analysis using ``sklearn.decomposition.PCA``."""
+
+    def __init__(self, n_components: Optional[int] = None, **kwargs) -> None:
+        self.n_components = n_components
+        self.kwargs = kwargs
+        self.model: Optional[PCA] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any = None) -> None:
+        X_np = self._to_array(X)
+        self.model = PCA(n_components=self.n_components, **self.kwargs)
+        self.model.fit(X_np)
+
+    def predict(self, X: Any) -> np.ndarray:
+        """Alias for :meth:`transform`."""
+        return self.transform(X)
+
+    def transform(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.transform(X_np)
+
+    def fit_transform(self, X: Any, y: Any = None) -> np.ndarray:
+        X_np = self._to_array(X)
+        self.model = PCA(n_components=self.n_components, **self.kwargs)
+        return self.model.fit_transform(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        joblib.dump(self.model, path)
+
+    def load(self, path: str) -> None:
+        self.model = joblib.load(path)

--- a/tensorus/models/tsne_embedding.py
+++ b/tensorus/models/tsne_embedding.py
@@ -1,0 +1,57 @@
+import numpy as np
+from typing import Any, Optional
+from sklearn.manifold import TSNE
+import joblib
+
+from .base import TensorusModel
+
+
+class TSNEEmbeddingModel(TensorusModel):
+    """t-SNE dimensionality reduction using ``sklearn.manifold.TSNE``."""
+
+    def __init__(self, n_components: int = 2, **kwargs) -> None:
+        self.n_components = n_components
+        self.kwargs = kwargs
+        self.model: Optional[TSNE] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any = None) -> None:
+        X_np = self._to_array(X)
+        self.model = TSNE(n_components=self.n_components, **self.kwargs)
+        self.model.fit(X_np)
+
+    def predict(self, X: Any) -> np.ndarray:
+        """Alias for :meth:`transform`."""
+        return self.transform(X)
+
+    def transform(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        if hasattr(self.model, "transform"):
+            X_np = self._to_array(X)
+            return self.model.transform(X_np)
+        raise NotImplementedError("TSNE transform is not available in this scikit-learn version")
+
+    def fit_transform(self, X: Any, y: Any = None) -> np.ndarray:
+        X_np = self._to_array(X)
+        self.model = TSNE(n_components=self.n_components, **self.kwargs)
+        return self.model.fit_transform(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        joblib.dump(self.model, path)
+
+    def load(self, path: str) -> None:
+        self.model = joblib.load(path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,8 @@ from tensorus.models.kmeans import KMeansClusteringModel
 from tensorus.models.knn_classifier import KNNClassifierModel
 from tensorus.models.random_forest_classifier import RandomForestClassifierModel
 from tensorus.models.random_forest_regressor import RandomForestRegressorModel
+from tensorus.models.pca_decomposition import PCADecompositionModel
+from tensorus.models.tsne_embedding import TSNEEmbeddingModel
 from tensorus.tensor_storage import TensorStorage
 from tensorus.models.utils import load_xy_from_storage, store_predictions
 
@@ -136,3 +138,29 @@ def test_random_forest_models(tmp_path):
     reg2 = RandomForestRegressorModel()
     reg2.load(str(save_reg))
     assert np.allclose(reg2.predict(X), preds_reg)
+
+
+def test_dimensionality_reduction_models(tmp_path):
+    X = np.array([[0.0, 1.0], [1.0, 0.0], [2.0, 1.0], [3.0, 0.0]])
+
+    pca = PCADecompositionModel(n_components=1)
+    X_pca = pca.fit_transform(X)
+    assert X_pca.shape == (4, 1)
+
+    save_pca = tmp_path / "pca.joblib"
+    pca.save(str(save_pca))
+    pca2 = PCADecompositionModel(n_components=1)
+    pca2.load(str(save_pca))
+    assert np.allclose(pca2.transform(X), X_pca)
+
+    tsne = TSNEEmbeddingModel(n_components=2, perplexity=2, random_state=42)
+    X_tsne = tsne.fit_transform(X)
+    assert X_tsne.shape == (4, 2)
+
+    save_tsne = tmp_path / "tsne.joblib"
+    tsne.save(str(save_tsne))
+    tsne2 = TSNEEmbeddingModel(n_components=2)
+    tsne2.load(str(save_tsne))
+    if hasattr(tsne2.model, "transform"):
+        assert np.allclose(tsne2.transform(X), tsne.transform(X))
+


### PR DESCRIPTION
## Summary
- add PCADecompositionModel and TSNEEmbeddingModel wrappers
- expose them via `tensorus.models`
- test PCA and tSNE on small arrays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407a9a18f8833198e4648c8328bf66