### PR TITLE
Add SEM and mixed-effects models

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,4 @@ pytest
 pytest-asyncio
 httpx==0.23.0
 scipy
+semopy>=2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ umap-learn
 pandas>=1.5.0
 arch>=5.7
 lifelines>=0.28
+semopy>=2.3

--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -38,6 +38,8 @@ from .garch_model import GARCHModel
 from .cox_ph_model import CoxPHModel
 from .anova import AnovaModel
 from .manova import ManovaModel
+from .mixed_effects_model import MixedEffectsModel
+from .structural_equation_model import StructuralEquationModel
 from .utils import load_xy_from_storage, store_predictions
 
 __all__ = [
@@ -80,6 +82,8 @@ __all__ = [
     "CoxPHModel",
     "AnovaModel",
     "ManovaModel",
+    "MixedEffectsModel",
+    "StructuralEquationModel",
     "load_xy_from_storage",
     "store_predictions",
 ]

--- a/tensorus/models/mixed_effects_model.py
+++ b/tensorus/models/mixed_effects_model.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+import joblib
+from typing import Any, Optional
+from statsmodels.regression.mixed_linear_model import MixedLM
+
+from .base import TensorusModel
+
+
+class MixedEffectsModel(TensorusModel):
+    """Multilevel linear model using ``statsmodels.MixedLM``."""
+
+    def __init__(self) -> None:
+        self.model: Optional[MixedLM] = None
+        self.result = None
+        self.exog_names: Optional[list[str]] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        if isinstance(arr, pd.Series) or isinstance(arr, pd.DataFrame):
+            return np.asarray(arr)
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be array-like")
+
+    def fit(self, X: Any, y: Any, groups: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y).reshape(-1)
+        groups_np = self._to_array(groups).reshape(-1)
+        if X_np.ndim == 1:
+            X_np = X_np.reshape(-1, 1)
+        df = pd.DataFrame(X_np, columns=[f"x{i}" for i in range(X_np.shape[1])])
+        df["y"] = y_np
+        df["groups"] = groups_np
+        exog = df[[f"x{i}" for i in range(X_np.shape[1])]]
+        endog = df["y"]
+        self.exog_names = list(exog.columns)
+        self.model = MixedLM(endog, exog, groups=df["groups"])
+        self.result = self.model.fit()
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.result is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        if X_np.ndim == 1:
+            X_np = X_np.reshape(-1, 1)
+        df = pd.DataFrame(X_np, columns=self.exog_names)
+        return self.result.predict(df)
+
+    def save(self, path: str) -> None:
+        if self.result is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        joblib.dump({"result": self.result, "exog_names": self.exog_names}, path)
+
+    def load(self, path: str) -> None:
+        obj = joblib.load(path)
+        self.result = obj.get("result")
+        self.exog_names = obj.get("exog_names")

--- a/tensorus/models/structural_equation_model.py
+++ b/tensorus/models/structural_equation_model.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import numpy as np
+import joblib
+from typing import Any, Optional
+from semopy import Model
+
+from .base import TensorusModel
+
+
+class StructuralEquationModel(TensorusModel):
+    """Wrapper around ``semopy.Model`` for structural equation modeling."""
+
+    def __init__(self, description: str) -> None:
+        self.description = description
+        self.model: Optional[Model] = None
+
+    def _to_dataframe(self, data: Any) -> pd.DataFrame:
+        if isinstance(data, pd.DataFrame):
+            return data
+        if isinstance(data, dict):
+            return pd.DataFrame(data)
+        if isinstance(data, np.ndarray):
+            return pd.DataFrame(data)
+        try:
+            import torch
+            if isinstance(data, torch.Tensor):
+                return pd.DataFrame(data.detach().cpu().numpy())
+        except Exception:
+            pass
+        raise TypeError("Input must be convertible to pandas DataFrame")
+
+    def fit(self, data: Any) -> None:
+        df = self._to_dataframe(data)
+        self.model = Model(self.description)
+        self.model.fit(df)
+
+    def predict(self, data: Any) -> pd.DataFrame:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        df = self._to_dataframe(data)
+        return self.model.predict(df)
+
+    def save(self, path: str) -> None:
+        """Persist the model description to ``path``."""
+        joblib.dump({"description": self.description}, path)
+
+    def load(self, path: str) -> None:
+        obj = joblib.load(path)
+        self.description = obj.get("description")
+        self.model = None

--- a/tests/test_statistical_models.py
+++ b/tests/test_statistical_models.py
@@ -3,6 +3,8 @@ import pandas as pd
 
 from tensorus.models.anova import AnovaModel
 from tensorus.models.manova import ManovaModel
+from tensorus.models.structural_equation_model import StructuralEquationModel
+from tensorus.models.mixed_effects_model import MixedEffectsModel
 
 
 def test_anova_model(tmp_path):
@@ -38,3 +40,43 @@ def test_manova_model(tmp_path):
     model2 = ManovaModel()
     model2.load(str(save_path))
     assert model2.summary().shape == frame.shape
+
+
+def test_structural_equation_model(tmp_path):
+    np.random.seed(0)
+    latent = np.random.normal(size=50)
+    x1 = latent + np.random.normal(size=50)
+    x2 = latent + np.random.normal(size=50)
+    x3 = np.random.normal(size=50)
+    data = pd.DataFrame({"x1": x1, "x2": x2, "x3": x3})
+    desc = "L =~ x1 + x2\nL ~ x3"
+    model = StructuralEquationModel(desc)
+    model.fit(data)
+    preds = model.predict(data)
+    assert isinstance(preds, pd.DataFrame)
+    save_path = tmp_path / "sem.pkl"
+    model.save(str(save_path))
+    model2 = StructuralEquationModel(desc)
+    model2.load(str(save_path))
+    model2.fit(data)
+    preds2 = model2.predict(data)
+    assert preds2.shape == preds.shape
+
+
+def test_mixed_effects_model(tmp_path):
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(20, 1))
+    groups = np.repeat(np.arange(4), 5)
+    beta = 0.5
+    group_effects = np.array([0.1, -0.2, 0.2, -0.1])
+    y = beta * X[:, 0] + group_effects[groups] + rng.normal(scale=0.01, size=20)
+    model = MixedEffectsModel()
+    model.fit(X, y, groups)
+    preds = model.predict(X)
+    assert len(preds) == len(y)
+    save_path = tmp_path / "mixed.pkl"
+    model.save(str(save_path))
+    model2 = MixedEffectsModel()
+    model2.load(str(save_path))
+    preds2 = model2.predict(X)
+    assert np.allclose(preds2, preds)


### PR DESCRIPTION
## Summary
- add new dependency semopy to requirements
- wrap statsmodels MixedLM in `MixedEffectsModel`
- create `StructuralEquationModel` wrapper for semopy
- expose new models via the models package
- extend statistical models tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414e1f78348331b5c09c4dce4ab05e