### PR TITLE
Add gradient boosting and external boosting models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,6 @@ pandas>=1.5.0
 arch>=5.7
 lifelines>=0.28
 semopy>=2.3
+xgboost
+lightgbm
+catboost

--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -23,6 +23,14 @@ from .lda_classifier import LDAClassifierModel
 from .qda_classifier import QDAClassifierModel
 from .random_forest_classifier import RandomForestClassifierModel
 from .random_forest_regressor import RandomForestRegressorModel
+from .gradient_boosting_classifier import GradientBoostingClassifierModel
+from .gradient_boosting_regressor import GradientBoostingRegressorModel
+from .xgboost_classifier import XGBoostClassifierModel
+from .xgboost_regressor import XGBoostRegressorModel
+from .lightgbm_classifier import LightGBMClassifierModel
+from .lightgbm_regressor import LightGBMRegressorModel
+from .catboost_classifier import CatBoostClassifierModel
+from .catboost_regressor import CatBoostRegressorModel
 from .pca_decomposition import PCADecompositionModel
 from .factor_analysis import FactorAnalysisModel
 from .cca import CCAModel
@@ -67,6 +75,14 @@ __all__ = [
     "QDAClassifierModel",
     "RandomForestClassifierModel",
     "RandomForestRegressorModel",
+    "GradientBoostingClassifierModel",
+    "GradientBoostingRegressorModel",
+    "XGBoostClassifierModel",
+    "XGBoostRegressorModel",
+    "LightGBMClassifierModel",
+    "LightGBMRegressorModel",
+    "CatBoostClassifierModel",
+    "CatBoostRegressorModel",
     "PCADecompositionModel",
     "FactorAnalysisModel",
     "CCAModel",
@@ -87,3 +103,13 @@ __all__ = [
     "load_xy_from_storage",
     "store_predictions",
 ]
+
+# Register models in the simple registry for convenience
+register_model("GradientBoostingClassifier", GradientBoostingClassifierModel)
+register_model("GradientBoostingRegressor", GradientBoostingRegressorModel)
+register_model("XGBoostClassifier", XGBoostClassifierModel)
+register_model("XGBoostRegressor", XGBoostRegressorModel)
+register_model("LightGBMClassifier", LightGBMClassifierModel)
+register_model("LightGBMRegressor", LightGBMRegressorModel)
+register_model("CatBoostClassifier", CatBoostClassifierModel)
+register_model("CatBoostRegressor", CatBoostRegressorModel)

--- a/tensorus/models/catboost_classifier.py
+++ b/tensorus/models/catboost_classifier.py
@@ -1,0 +1,49 @@
+import numpy as np
+from typing import Any, Optional
+from catboost import CatBoostClassifier
+
+from .base import TensorusModel
+
+
+class CatBoostClassifierModel(TensorusModel):
+    """Wrapper for ``catboost.CatBoostClassifier`` with optional GPU support."""
+
+    def __init__(self, use_gpu: bool = False, **kwargs) -> None:
+        self.use_gpu = use_gpu
+        self.kwargs = kwargs
+        self.model: Optional[CatBoostClassifier] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y)
+        params = dict(self.kwargs)
+        if self.use_gpu:
+            params.setdefault("task_type", "GPU")
+        self.model = CatBoostClassifier(**params)
+        self.model.fit(X_np, y_np, verbose=False)
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.predict(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        self.model.save_model(path)
+
+    def load(self, path: str) -> None:
+        self.model = CatBoostClassifier()
+        self.model.load_model(path)

--- a/tensorus/models/catboost_regressor.py
+++ b/tensorus/models/catboost_regressor.py
@@ -1,0 +1,49 @@
+import numpy as np
+from typing import Any, Optional
+from catboost import CatBoostRegressor
+
+from .base import TensorusModel
+
+
+class CatBoostRegressorModel(TensorusModel):
+    """Wrapper for ``catboost.CatBoostRegressor`` with optional GPU support."""
+
+    def __init__(self, use_gpu: bool = False, **kwargs) -> None:
+        self.use_gpu = use_gpu
+        self.kwargs = kwargs
+        self.model: Optional[CatBoostRegressor] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y)
+        params = dict(self.kwargs)
+        if self.use_gpu:
+            params.setdefault("task_type", "GPU")
+        self.model = CatBoostRegressor(**params)
+        self.model.fit(X_np, y_np, verbose=False)
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.predict(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        self.model.save_model(path)
+
+    def load(self, path: str) -> None:
+        self.model = CatBoostRegressor()
+        self.model.load_model(path)

--- a/tensorus/models/gradient_boosting_classifier.py
+++ b/tensorus/models/gradient_boosting_classifier.py
@@ -1,0 +1,45 @@
+import numpy as np
+from typing import Any, Optional
+from sklearn.ensemble import GradientBoostingClassifier
+import joblib
+
+from .base import TensorusModel
+
+
+class GradientBoostingClassifierModel(TensorusModel):
+    """Gradient boosting classifier using ``sklearn.ensemble.GradientBoostingClassifier``."""
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.model: Optional[GradientBoostingClassifier] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y)
+        self.model = GradientBoostingClassifier(**self.kwargs)
+        self.model.fit(X_np, y_np)
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.predict(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        joblib.dump(self.model, path)
+
+    def load(self, path: str) -> None:
+        self.model = joblib.load(path)

--- a/tensorus/models/gradient_boosting_regressor.py
+++ b/tensorus/models/gradient_boosting_regressor.py
@@ -1,0 +1,45 @@
+import numpy as np
+from typing import Any, Optional
+from sklearn.ensemble import GradientBoostingRegressor
+import joblib
+
+from .base import TensorusModel
+
+
+class GradientBoostingRegressorModel(TensorusModel):
+    """Gradient boosting regressor using ``sklearn.ensemble.GradientBoostingRegressor``."""
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.model: Optional[GradientBoostingRegressor] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y)
+        self.model = GradientBoostingRegressor(**self.kwargs)
+        self.model.fit(X_np, y_np)
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.predict(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        joblib.dump(self.model, path)
+
+    def load(self, path: str) -> None:
+        self.model = joblib.load(path)

--- a/tensorus/models/lightgbm_classifier.py
+++ b/tensorus/models/lightgbm_classifier.py
@@ -1,0 +1,49 @@
+import numpy as np
+from typing import Any, Optional
+from lightgbm import LGBMClassifier
+import joblib
+
+from .base import TensorusModel
+
+
+class LightGBMClassifierModel(TensorusModel):
+    """Wrapper for ``lightgbm.LGBMClassifier`` with optional GPU support."""
+
+    def __init__(self, use_gpu: bool = False, **kwargs) -> None:
+        self.use_gpu = use_gpu
+        self.kwargs = kwargs
+        self.model: Optional[LGBMClassifier] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y)
+        params = dict(self.kwargs)
+        if self.use_gpu:
+            params.setdefault("device", "gpu")
+        self.model = LGBMClassifier(**params)
+        self.model.fit(X_np, y_np)
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.predict(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        joblib.dump(self.model, path)
+
+    def load(self, path: str) -> None:
+        self.model = joblib.load(path)

--- a/tensorus/models/lightgbm_regressor.py
+++ b/tensorus/models/lightgbm_regressor.py
@@ -1,0 +1,49 @@
+import numpy as np
+from typing import Any, Optional
+from lightgbm import LGBMRegressor
+import joblib
+
+from .base import TensorusModel
+
+
+class LightGBMRegressorModel(TensorusModel):
+    """Wrapper for ``lightgbm.LGBMRegressor`` with optional GPU support."""
+
+    def __init__(self, use_gpu: bool = False, **kwargs) -> None:
+        self.use_gpu = use_gpu
+        self.kwargs = kwargs
+        self.model: Optional[LGBMRegressor] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y)
+        params = dict(self.kwargs)
+        if self.use_gpu:
+            params.setdefault("device", "gpu")
+        self.model = LGBMRegressor(**params)
+        self.model.fit(X_np, y_np)
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.predict(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        joblib.dump(self.model, path)
+
+    def load(self, path: str) -> None:
+        self.model = joblib.load(path)

--- a/tensorus/models/xgboost_classifier.py
+++ b/tensorus/models/xgboost_classifier.py
@@ -1,0 +1,50 @@
+import numpy as np
+from typing import Any, Optional
+from xgboost import XGBClassifier
+
+from .base import TensorusModel
+
+
+class XGBoostClassifierModel(TensorusModel):
+    """Wrapper for ``xgboost.XGBClassifier`` with optional GPU support."""
+
+    def __init__(self, use_gpu: bool = False, **kwargs) -> None:
+        self.use_gpu = use_gpu
+        self.kwargs = kwargs
+        self.model: Optional[XGBClassifier] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y)
+        params = dict(self.kwargs)
+        if self.use_gpu:
+            params.setdefault("tree_method", "gpu_hist")
+            params.setdefault("predictor", "gpu_predictor")
+        self.model = XGBClassifier(**params)
+        self.model.fit(X_np, y_np)
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.predict(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        self.model.save_model(path)
+
+    def load(self, path: str) -> None:
+        self.model = XGBClassifier()
+        self.model.load_model(path)

--- a/tensorus/models/xgboost_regressor.py
+++ b/tensorus/models/xgboost_regressor.py
@@ -1,0 +1,50 @@
+import numpy as np
+from typing import Any, Optional
+from xgboost import XGBRegressor
+
+from .base import TensorusModel
+
+
+class XGBoostRegressorModel(TensorusModel):
+    """Wrapper for ``xgboost.XGBRegressor`` with optional GPU support."""
+
+    def __init__(self, use_gpu: bool = False, **kwargs) -> None:
+        self.use_gpu = use_gpu
+        self.kwargs = kwargs
+        self.model: Optional[XGBRegressor] = None
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_np = self._to_array(X)
+        y_np = self._to_array(y)
+        params = dict(self.kwargs)
+        if self.use_gpu:
+            params.setdefault("tree_method", "gpu_hist")
+            params.setdefault("predictor", "gpu_predictor")
+        self.model = XGBRegressor(**params)
+        self.model.fit(X_np, y_np)
+
+    def predict(self, X: Any) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        X_np = self._to_array(X)
+        return self.model.predict(X_np)
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        self.model.save_model(path)
+
+    def load(self, path: str) -> None:
+        self.model = XGBRegressor()
+        self.model.load_model(path)

--- a/tests/test_boosting_models.py
+++ b/tests/test_boosting_models.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from tensorus.models.gradient_boosting_classifier import GradientBoostingClassifierModel
+from tensorus.models.gradient_boosting_regressor import GradientBoostingRegressorModel
+from tensorus.models.xgboost_classifier import XGBoostClassifierModel
+from tensorus.models.xgboost_regressor import XGBoostRegressorModel
+from tensorus.models.lightgbm_classifier import LightGBMClassifierModel
+from tensorus.models.lightgbm_regressor import LightGBMRegressorModel
+from tensorus.models.catboost_classifier import CatBoostClassifierModel
+from tensorus.models.catboost_regressor import CatBoostRegressorModel
+
+
+@pytest.mark.parametrize("Model", [
+    GradientBoostingClassifierModel,
+    XGBoostClassifierModel,
+    LightGBMClassifierModel,
+    CatBoostClassifierModel,
+])
+def test_boosting_classifiers(Model):
+    X = np.array([[0.0], [1.0], [2.0], [3.0]])
+    y = np.array([0, 0, 1, 1])
+    model = Model()
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert len(preds) == len(y)
+
+
+@pytest.mark.parametrize("Model", [
+    GradientBoostingRegressorModel,
+    XGBoostRegressorModel,
+    LightGBMRegressorModel,
+    CatBoostRegressorModel,
+])
+def test_boosting_regressors(Model):
+    X = np.array([[1.0], [2.0], [3.0], [4.0]])
+    y = np.array([3.0, 5.0, 7.0, 9.0])
+    model = Model()
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert len(preds) == len(y)


### PR DESCRIPTION
## Summary
- implement scikit-learn gradient boosting models
- add wrappers for xgboost, lightgbm and catboost
- register new models
- add dependencies
- test the new models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684151f4b0708331bd3e7a6a41ef7e05