### PR TITLE
Add CNN models with torchvision

### DIFF
--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -40,6 +40,12 @@ from .isolation_forest import IsolationForestModel
 from .one_class_svm import OneClassSVMModel
 from .mlp_classifier import MLPClassifierModel
 from .stacked_rbm_classifier import StackedRBMClassifierModel
+from .lenet import LeNetModel
+from .alexnet import AlexNetModel
+from .vgg import VGGModel
+from .resnet import ResNetModel
+from .mobilenet import MobileNetModel
+from .efficientnet import EfficientNetModel
 from .label_propagation import LabelPropagationModel
 from .self_training_classifier import SelfTrainingClassifierModel
 from .arima_model import ARIMAModel
@@ -97,6 +103,12 @@ __all__ = [
     "SelfTrainingClassifierModel",
     "MLPClassifierModel",
     "StackedRBMClassifierModel",
+    "LeNetModel",
+    "AlexNetModel",
+    "VGGModel",
+    "ResNetModel",
+    "MobileNetModel",
+    "EfficientNetModel",
     "ARIMAModel",
     "SARIMAModel",
     "ExponentialSmoothingModel",
@@ -119,3 +131,9 @@ register_model("LightGBMClassifier", LightGBMClassifierModel)
 register_model("LightGBMRegressor", LightGBMRegressorModel)
 register_model("CatBoostClassifier", CatBoostClassifierModel)
 register_model("CatBoostRegressor", CatBoostRegressorModel)
+register_model("LeNet", LeNetModel)
+register_model("AlexNet", AlexNetModel)
+register_model("VGG", VGGModel)
+register_model("ResNet", ResNetModel)
+register_model("MobileNet", MobileNetModel)
+register_model("EfficientNet", EfficientNetModel)

--- a/tensorus/models/alexnet.py
+++ b/tensorus/models/alexnet.py
@@ -1,0 +1,21 @@
+from torch import nn
+from torchvision import models
+
+from .cnn_base import CNNModelBase
+
+
+class AlexNetModel(CNNModelBase):
+    """AlexNet classifier using ``torchvision.models.alexnet``."""
+
+    def __init__(
+        self,
+        num_classes: int = 1000,
+        pretrained: bool = False,
+        lr: float = 1e-3,
+        epochs: int = 1,
+    ) -> None:
+        weights = models.AlexNet_Weights.DEFAULT if pretrained else None
+        model = models.alexnet(weights=weights)
+        if num_classes != 1000:
+            model.classifier[6] = nn.Linear(model.classifier[6].in_features, num_classes)
+        super().__init__(model, lr=lr, epochs=epochs)

--- a/tensorus/models/cnn_base.py
+++ b/tensorus/models/cnn_base.py
@@ -1,0 +1,56 @@
+import torch
+import numpy as np
+from typing import Any
+from torch import nn
+
+from .base import TensorusModel
+
+
+class CNNModelBase(TensorusModel):
+    """Base class for convolutional neural network models."""
+
+    def __init__(self, model: nn.Module, lr: float = 1e-3, epochs: int = 1) -> None:
+        self.model = model
+        self.lr = lr
+        self.epochs = epochs
+
+    def _to_tensor(self, arr: Any) -> torch.Tensor:
+        if isinstance(arr, torch.Tensor):
+            return arr.float()
+        if isinstance(arr, np.ndarray):
+            return torch.from_numpy(arr).float()
+        raise TypeError("Input must be a torch.Tensor or numpy.ndarray")
+
+    def _to_label_tensor(self, arr: Any) -> torch.Tensor:
+        if isinstance(arr, torch.Tensor):
+            return arr.long()
+        if isinstance(arr, np.ndarray):
+            return torch.from_numpy(arr).long()
+        raise TypeError("Labels must be a torch.Tensor or numpy.ndarray")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_t = self._to_tensor(X)
+        y_t = self._to_label_tensor(y)
+        optimizer = torch.optim.Adam(self.model.parameters(), lr=self.lr)
+        criterion = nn.CrossEntropyLoss()
+        self.model.train()
+        for _ in range(self.epochs):
+            optimizer.zero_grad()
+            outputs = self.model(X_t)
+            loss = criterion(outputs, y_t)
+            loss.backward()
+            optimizer.step()
+
+    def predict(self, X: Any) -> torch.Tensor:
+        X_t = self._to_tensor(X)
+        self.model.eval()
+        with torch.no_grad():
+            logits = self.model(X_t)
+            return logits.argmax(dim=1)
+
+    def save(self, path: str) -> None:
+        torch.save({"state_dict": self.model.state_dict()}, path)
+
+    def load(self, path: str) -> None:
+        data = torch.load(path, map_location="cpu")
+        self.model.load_state_dict(data["state_dict"])

--- a/tensorus/models/efficientnet.py
+++ b/tensorus/models/efficientnet.py
@@ -1,0 +1,21 @@
+from torch import nn
+from torchvision import models
+
+from .cnn_base import CNNModelBase
+
+
+class EfficientNetModel(CNNModelBase):
+    """EfficientNet-B0 classifier using ``torchvision.models.efficientnet_b0``."""
+
+    def __init__(
+        self,
+        num_classes: int = 1000,
+        pretrained: bool = False,
+        lr: float = 1e-3,
+        epochs: int = 1,
+    ) -> None:
+        weights = models.EfficientNet_B0_Weights.DEFAULT if pretrained else None
+        model = models.efficientnet_b0(weights=weights)
+        if num_classes != 1000:
+            model.classifier[1] = nn.Linear(model.classifier[1].in_features, num_classes)
+        super().__init__(model, lr=lr, epochs=epochs)

--- a/tensorus/models/lenet.py
+++ b/tensorus/models/lenet.py
@@ -1,0 +1,39 @@
+import torch
+from torch import nn
+
+from .cnn_base import CNNModelBase
+
+
+class LeNet(nn.Module):
+    """Simple LeNet-5 architecture."""
+
+    def __init__(self, num_classes: int = 10) -> None:
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(1, 6, 5),
+            nn.ReLU(),
+            nn.AvgPool2d(2),
+            nn.Conv2d(6, 16, 5),
+            nn.ReLU(),
+            nn.AvgPool2d(2),
+        )
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(16 * 5 * 5, 120),
+            nn.ReLU(),
+            nn.Linear(120, 84),
+            nn.ReLU(),
+            nn.Linear(84, num_classes),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        x = self.classifier(x)
+        return x
+
+
+class LeNetModel(CNNModelBase):
+    """LeNet classifier."""
+
+    def __init__(self, num_classes: int = 10, lr: float = 1e-3, epochs: int = 1) -> None:
+        super().__init__(LeNet(num_classes=num_classes), lr=lr, epochs=epochs)

--- a/tensorus/models/mobilenet.py
+++ b/tensorus/models/mobilenet.py
@@ -1,0 +1,21 @@
+from torch import nn
+from torchvision import models
+
+from .cnn_base import CNNModelBase
+
+
+class MobileNetModel(CNNModelBase):
+    """MobileNetV2 classifier using ``torchvision.models.mobilenet_v2``."""
+
+    def __init__(
+        self,
+        num_classes: int = 1000,
+        pretrained: bool = False,
+        lr: float = 1e-3,
+        epochs: int = 1,
+    ) -> None:
+        weights = models.MobileNet_V2_Weights.DEFAULT if pretrained else None
+        model = models.mobilenet_v2(weights=weights)
+        if num_classes != 1000:
+            model.classifier[1] = nn.Linear(model.classifier[1].in_features, num_classes)
+        super().__init__(model, lr=lr, epochs=epochs)

--- a/tensorus/models/resnet.py
+++ b/tensorus/models/resnet.py
@@ -1,0 +1,21 @@
+from torch import nn
+from torchvision import models
+
+from .cnn_base import CNNModelBase
+
+
+class ResNetModel(CNNModelBase):
+    """ResNet18 classifier using ``torchvision.models.resnet18``."""
+
+    def __init__(
+        self,
+        num_classes: int = 1000,
+        pretrained: bool = False,
+        lr: float = 1e-3,
+        epochs: int = 1,
+    ) -> None:
+        weights = models.ResNet18_Weights.DEFAULT if pretrained else None
+        model = models.resnet18(weights=weights)
+        if num_classes != 1000:
+            model.fc = nn.Linear(model.fc.in_features, num_classes)
+        super().__init__(model, lr=lr, epochs=epochs)

--- a/tensorus/models/vgg.py
+++ b/tensorus/models/vgg.py
@@ -1,0 +1,21 @@
+from torch import nn
+from torchvision import models
+
+from .cnn_base import CNNModelBase
+
+
+class VGGModel(CNNModelBase):
+    """VGG16 classifier using ``torchvision.models.vgg16``."""
+
+    def __init__(
+        self,
+        num_classes: int = 1000,
+        pretrained: bool = False,
+        lr: float = 1e-3,
+        epochs: int = 1,
+    ) -> None:
+        weights = models.VGG16_Weights.DEFAULT if pretrained else None
+        model = models.vgg16(weights=weights)
+        if num_classes != 1000:
+            model.classifier[6] = nn.Linear(model.classifier[6].in_features, num_classes)
+        super().__init__(model, lr=lr, epochs=epochs)

--- a/tests/test_cnn_models.py
+++ b/tests/test_cnn_models.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+from tensorus.models.lenet import LeNetModel
+from tensorus.models.alexnet import AlexNetModel
+from tensorus.models.vgg import VGGModel
+from tensorus.models.resnet import ResNetModel
+from tensorus.models.mobilenet import MobileNetModel
+from tensorus.models.efficientnet import EfficientNetModel
+
+
+@pytest.mark.parametrize(
+    "Model,input_shape",
+    [
+        (LeNetModel, (1, 1, 32, 32)),
+        (AlexNetModel, (1, 3, 224, 224)),
+        (VGGModel, (1, 3, 224, 224)),
+        (ResNetModel, (1, 3, 224, 224)),
+        (MobileNetModel, (1, 3, 224, 224)),
+        (EfficientNetModel, (1, 3, 224, 224)),
+    ],
+)
+def test_cnn_forward(Model, input_shape):
+    if Model is LeNetModel:
+        model = Model()
+    else:
+        model = Model(pretrained=False)
+    x = torch.randn(*input_shape)
+    preds = model.predict(x)
+    assert preds.shape[0] == input_shape[0]


### PR DESCRIPTION
## Summary
- implement CNNModelBase with training/prediction helpers
- add LeNet, AlexNet, VGG, ResNet, MobileNet and EfficientNet models
- register new models in the registry
- provide lightweight tests for CNN forward pass

## Testing
- `pip install -r requirements.txt --quiet`
- `pip install -r requirements-test.txt --quiet`
- `pip install -e . --quiet`
- `pytest tests/test_cnn_models.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415acdd6f48331b07a1892e4ba65f2