### PR TITLE
Add RNN models with bidirectional wrapper

### DIFF
--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -46,6 +46,13 @@ from .vgg import VGGModel
 from .resnet import ResNetModel
 from .mobilenet import MobileNetModel
 from .efficientnet import EfficientNetModel
+from .rnn_models import (
+    LSTMModule,
+    GRUModule,
+    BidirectionalWrapper,
+    LSTMClassifierModel,
+    GRUClassifierModel,
+)
 from .label_propagation import LabelPropagationModel
 from .self_training_classifier import SelfTrainingClassifierModel
 from .arima_model import ARIMAModel
@@ -109,6 +116,11 @@ __all__ = [
     "ResNetModel",
     "MobileNetModel",
     "EfficientNetModel",
+    "LSTMModule",
+    "GRUModule",
+    "BidirectionalWrapper",
+    "LSTMClassifierModel",
+    "GRUClassifierModel",
     "ARIMAModel",
     "SARIMAModel",
     "ExponentialSmoothingModel",
@@ -137,3 +149,5 @@ register_model("VGG", VGGModel)
 register_model("ResNet", ResNetModel)
 register_model("MobileNet", MobileNetModel)
 register_model("EfficientNet", EfficientNetModel)
+register_model("LSTMClassifier", LSTMClassifierModel)
+register_model("GRUClassifier", GRUClassifierModel)

--- a/tensorus/models/rnn_models.py
+++ b/tensorus/models/rnn_models.py
@@ -1,0 +1,194 @@
+import copy
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+
+from .base import TensorusModel
+
+
+class LSTMModule(nn.Module):
+    """Simple wrapper around ``nn.LSTM`` supporting stacked layers."""
+
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1) -> None:
+        super().__init__()
+        self.hidden_size = int(hidden_size)
+        self.num_layers = int(num_layers)
+        self.lstm = nn.LSTM(
+            input_size,
+            hidden_size,
+            num_layers=self.num_layers,
+            batch_first=True,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out, _ = self.lstm(x)
+        return out
+
+
+class GRUModule(nn.Module):
+    """Simple wrapper around ``nn.GRU`` supporting stacked layers."""
+
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1) -> None:
+        super().__init__()
+        self.hidden_size = int(hidden_size)
+        self.num_layers = int(num_layers)
+        self.gru = nn.GRU(
+            input_size,
+            hidden_size,
+            num_layers=self.num_layers,
+            batch_first=True,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out, _ = self.gru(x)
+        return out
+
+
+class BidirectionalWrapper(nn.Module):
+    """Bidirectional processing wrapper for RNN modules."""
+
+    def __init__(self, module: nn.Module) -> None:
+        super().__init__()
+        self.fwd = module
+        self.bwd = copy.deepcopy(module)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out_fwd = self.fwd(x)
+        out_bwd = self.bwd(torch.flip(x, dims=[1]))
+        out_bwd = torch.flip(out_bwd, dims=[1])
+        return torch.cat([out_fwd, out_bwd], dim=-1)
+
+
+class LSTMClassifierModel(TensorusModel):
+    """Sequence classifier using an LSTM backbone."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        num_layers: int = 1,
+        n_classes: int = 2,
+        bidirectional: bool = False,
+        lr: float = 1e-3,
+        epochs: int = 10,
+    ) -> None:
+        self.input_size = int(input_size)
+        self.hidden_size = int(hidden_size)
+        self.num_layers = int(num_layers)
+        self.n_classes = int(n_classes)
+        self.bidirectional = bool(bidirectional)
+        self.lr = lr
+        self.epochs = epochs
+        base = LSTMModule(self.input_size, self.hidden_size, self.num_layers)
+        if bidirectional:
+            self.rnn = BidirectionalWrapper(base)
+            out_dim = self.hidden_size * 2
+        else:
+            self.rnn = base
+            out_dim = self.hidden_size
+        self.fc = nn.Linear(out_dim, self.n_classes)
+
+    def _to_tensor(self, arr: Any) -> torch.Tensor:
+        if isinstance(arr, torch.Tensor):
+            return arr.float()
+        if isinstance(arr, np.ndarray):
+            return torch.from_numpy(arr).float()
+        raise TypeError("Input must be a torch.Tensor or numpy.ndarray")
+
+    def _to_label_tensor(self, arr: Any) -> torch.Tensor:
+        if isinstance(arr, torch.Tensor):
+            return arr.long()
+        if isinstance(arr, np.ndarray):
+            return torch.from_numpy(arr).long()
+        raise TypeError("Labels must be a torch.Tensor or numpy.ndarray")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_t = self._to_tensor(X)
+        y_t = self._to_label_tensor(y)
+        optimizer = torch.optim.Adam(list(self.rnn.parameters()) + list(self.fc.parameters()), lr=self.lr)
+        criterion = nn.CrossEntropyLoss()
+        self.rnn.train()
+        self.fc.train()
+        for _ in range(self.epochs):
+            optimizer.zero_grad()
+            out = self.rnn(X_t)
+            logits = self.fc(out[:, -1, :])
+            loss = criterion(logits, y_t)
+            loss.backward()
+            optimizer.step()
+
+    def predict(self, X: Any) -> torch.Tensor:
+        X_t = self._to_tensor(X)
+        self.rnn.eval()
+        self.fc.eval()
+        with torch.no_grad():
+            out = self.rnn(X_t)
+            logits = self.fc(out[:, -1, :])
+            return logits.argmax(dim=1)
+
+    def save(self, path: str) -> None:
+        torch.save(
+            {
+                'state_dict': {
+                    'rnn': self.rnn.state_dict(),
+                    'fc': self.fc.state_dict(),
+                },
+                'config': {
+                    'input_size': self.input_size,
+                    'hidden_size': self.hidden_size,
+                    'num_layers': self.num_layers,
+                    'n_classes': self.n_classes,
+                    'bidirectional': self.bidirectional,
+                    'lr': self.lr,
+                    'epochs': self.epochs,
+                },
+            },
+            path,
+        )
+
+    def load(self, path: str) -> None:
+        data = torch.load(path, map_location='cpu')
+        cfg = data.get('config', {})
+        self.__init__(
+            cfg.get('input_size', self.input_size),
+            cfg.get('hidden_size', self.hidden_size),
+            cfg.get('num_layers', self.num_layers),
+            cfg.get('n_classes', self.n_classes),
+            cfg.get('bidirectional', self.bidirectional),
+            cfg.get('lr', self.lr),
+            cfg.get('epochs', self.epochs),
+        )
+        self.rnn.load_state_dict(data['state_dict']['rnn'])
+        self.fc.load_state_dict(data['state_dict']['fc'])
+
+
+class GRUClassifierModel(LSTMClassifierModel):
+    """Sequence classifier using a GRU backbone."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        num_layers: int = 1,
+        n_classes: int = 2,
+        bidirectional: bool = False,
+        lr: float = 1e-3,
+        epochs: int = 10,
+    ) -> None:
+        self.input_size = int(input_size)
+        self.hidden_size = int(hidden_size)
+        self.num_layers = int(num_layers)
+        self.n_classes = int(n_classes)
+        self.bidirectional = bool(bidirectional)
+        self.lr = lr
+        self.epochs = epochs
+        base = GRUModule(self.input_size, self.hidden_size, self.num_layers)
+        if bidirectional:
+            self.rnn = BidirectionalWrapper(base)
+            out_dim = self.hidden_size * 2
+        else:
+            self.rnn = base
+            out_dim = self.hidden_size
+        self.fc = nn.Linear(out_dim, self.n_classes)

--- a/tests/test_rnn_models.py
+++ b/tests/test_rnn_models.py
@@ -1,0 +1,59 @@
+import numpy as np
+import torch
+
+from tensorus.models.rnn_models import (
+    LSTMModule,
+    GRUModule,
+    BidirectionalWrapper,
+    LSTMClassifierModel,
+    GRUClassifierModel,
+)
+
+
+def _generate_data():
+    X = np.array([
+        [[0.0], [0.0], [0.0]],
+        [[1.0], [1.0], [1.0]],
+        [[2.0], [2.0], [2.0]],
+        [[3.0], [3.0], [3.0]],
+    ])
+    y = np.array([0, 0, 1, 1])
+    return X, y
+
+
+def test_lstm_classifier():
+    X, y = _generate_data()
+    model = LSTMClassifierModel(
+        input_size=1,
+        hidden_size=4,
+        num_layers=2,
+        n_classes=2,
+        lr=0.1,
+        epochs=200,
+    )
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert torch.equal(preds, torch.tensor(y))
+
+
+def test_gru_classifier():
+    X, y = _generate_data()
+    model = GRUClassifierModel(
+        input_size=1,
+        hidden_size=4,
+        num_layers=2,
+        n_classes=2,
+        lr=0.1,
+        epochs=200,
+    )
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert torch.equal(preds, torch.tensor(y))
+
+
+def test_bidirectional_wrapper_output_dim():
+    module = LSTMModule(input_size=2, hidden_size=3)
+    wrapper = BidirectionalWrapper(module)
+    x = torch.randn(5, 7, 2)
+    out = wrapper(x)
+    assert out.shape == (5, 7, 6)


### PR DESCRIPTION
## Summary
- implement `LSTMModule`, `GRUModule`, and a `BidirectionalWrapper`
- expose `LSTMClassifierModel` and `GRUClassifierModel`
- register new models
- add tests for RNN classifiers and the wrapper

## Testing
- `pytest tests/test_rnn_models.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841692dc84083318ae3080c3672e66d