### PR TITLE
Add gensim embedding and NER model

### DIFF
--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -36,6 +36,8 @@ from .factor_analysis import FactorAnalysisModel
 from .cca import CCAModel
 from .tsne_embedding import TSNEEmbeddingModel
 from .umap_embedding import UMAPEmbeddingModel
+from .word2vec_model import Word2VecModel
+from .glove_model import GloVeModel
 from .isolation_forest import IsolationForestModel
 from .one_class_svm import OneClassSVMModel
 from .mlp_classifier import MLPClassifierModel
@@ -77,6 +79,7 @@ from .diffusion_model import DiffusionModel
 from .flow_based_model import FlowBasedModel
 from .gcn_classifier import GCNClassifierModel
 from .gat_classifier import GATClassifierModel
+from .named_entity_recognition import NamedEntityRecognitionModel
 from .utils import load_xy_from_storage, store_predictions
 
 __all__ = [
@@ -117,6 +120,8 @@ __all__ = [
     "CCAModel",
     "TSNEEmbeddingModel",
     "UMAPEmbeddingModel",
+    "Word2VecModel",
+    "GloVeModel",
     "IsolationForestModel",
     "OneClassSVMModel",
     "LabelPropagationModel",
@@ -129,6 +134,7 @@ __all__ = [
     "FlowBasedModel",
     "GCNClassifierModel",
     "GATClassifierModel",
+    "NamedEntityRecognitionModel",
     "LeNetModel",
     "AlexNetModel",
     "VGGModel",
@@ -186,3 +192,6 @@ register_model("Diffusion", DiffusionModel)
 register_model("FlowBased", FlowBasedModel)
 register_model("GCNClassifier", GCNClassifierModel)
 register_model("GATClassifier", GATClassifierModel)
+register_model("Word2Vec", Word2VecModel)
+register_model("GloVe", GloVeModel)
+register_model("NamedEntityRecognition", NamedEntityRecognitionModel)

--- a/tensorus/models/glove_model.py
+++ b/tensorus/models/glove_model.py
@@ -1,0 +1,101 @@
+import numpy as np
+from collections import defaultdict
+from typing import Iterable, List, Optional
+
+from gensim.corpora import Dictionary
+import joblib
+
+from .base import TensorusModel
+
+
+class GloVeModel(TensorusModel):
+    """Minimal GloVe embedding implementation using ``gensim`` utilities."""
+
+    def __init__(
+        self,
+        vector_size: int = 50,
+        window: int = 5,
+        iterations: int = 10,
+        x_max: int = 100,
+        alpha: float = 0.75,
+        lr: float = 0.05,
+    ) -> None:
+        self.vector_size = int(vector_size)
+        self.window = int(window)
+        self.iterations = int(iterations)
+        self.x_max = int(x_max)
+        self.alpha = float(alpha)
+        self.lr = lr
+        self.dictionary: Optional[Dictionary] = None
+        self.wi: Optional[np.ndarray] = None
+        self.wj: Optional[np.ndarray] = None
+        self.bi: Optional[np.ndarray] = None
+        self.bj: Optional[np.ndarray] = None
+        self.embeddings: Optional[np.ndarray] = None
+
+    def _build_cooc(self, corpus: List[List[str]]):
+        self.dictionary = Dictionary(corpus)
+        cooc = defaultdict(float)
+        for sentence in corpus:
+            ids = [self.dictionary.token2id[w] for w in sentence if w in self.dictionary.token2id]
+            for idx, i in enumerate(ids):
+                start = max(0, idx - self.window)
+                end = min(len(ids), idx + self.window + 1)
+                for jdx in range(start, end):
+                    if jdx == idx:
+                        continue
+                    j = ids[jdx]
+                    distance = abs(jdx - idx)
+                    cooc[(i, j)] += 1.0 / distance
+        return cooc
+
+    def fit(self, sentences: Iterable[List[str]], y: any = None) -> None:
+        corpus = list(sentences)
+        cooc = self._build_cooc(corpus)
+        vocab_size = len(self.dictionary)
+        self.wi = np.random.randn(vocab_size, self.vector_size) / np.sqrt(self.vector_size)
+        self.wj = np.random.randn(vocab_size, self.vector_size) / np.sqrt(self.vector_size)
+        self.bi = np.zeros(vocab_size)
+        self.bj = np.zeros(vocab_size)
+
+        for _ in range(self.iterations):
+            for (i, j), x in cooc.items():
+                weight = (x / self.x_max) ** self.alpha if x < self.x_max else 1.0
+                diff = np.dot(self.wi[i], self.wj[j]) + self.bi[i] + self.bj[j] - np.log(x)
+                grad = weight * diff
+                self.wi[i] -= self.lr * grad * self.wj[j]
+                self.wj[j] -= self.lr * grad * self.wi[i]
+                self.bi[i] -= self.lr * grad
+                self.bj[j] -= self.lr * grad
+
+        self.embeddings = self.wi + self.wj
+
+    def predict(self, tokens: List[str]) -> np.ndarray:
+        if self.embeddings is None or self.dictionary is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        return np.vstack([self.embeddings[self.dictionary.token2id[t]] for t in tokens])
+
+    def save(self, path: str) -> None:
+        if self.embeddings is None or self.dictionary is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        joblib.dump(
+            {
+                "wi": self.wi,
+                "wj": self.wj,
+                "bi": self.bi,
+                "bj": self.bj,
+                "token2id": self.dictionary.token2id,
+            },
+            path,
+        )
+
+    def load(self, path: str) -> None:
+        data = joblib.load(path)
+        self.wi = data["wi"]
+        self.wj = data["wj"]
+        self.bi = data["bi"]
+        self.bj = data["bj"]
+        self.dictionary = Dictionary()
+        self.dictionary.token2id = data["token2id"]
+        self.dictionary.id2token = {v: k for k, v in data["token2id"].items()}
+        self.embeddings = self.wi + self.wj

--- a/tensorus/models/named_entity_recognition.py
+++ b/tensorus/models/named_entity_recognition.py
@@ -1,0 +1,103 @@
+import numpy as np
+import torch
+from torch import nn
+from TorchCRF import CRF
+from typing import Any, Optional
+
+from .base import TensorusModel
+
+
+class NamedEntityRecognitionModel(TensorusModel, nn.Module):
+    """BiLSTM-CRF model for sequence tagging."""
+
+    def __init__(
+        self,
+        vocab_size: int,
+        tagset_size: int,
+        embedding_dim: int = 32,
+        hidden_dim: int = 64,
+        lr: float = 0.1,
+        epochs: int = 5,
+    ) -> None:
+        nn.Module.__init__(self)
+        self.vocab_size = int(vocab_size)
+        self.tagset_size = int(tagset_size)
+        self.embedding_dim = int(embedding_dim)
+        self.hidden_dim = int(hidden_dim)
+        self.lr = lr
+        self.epochs = epochs
+
+        self.embed = nn.Embedding(self.vocab_size, self.embedding_dim)
+        self.lstm = nn.LSTM(
+            self.embedding_dim,
+            self.hidden_dim // 2,
+            num_layers=1,
+            bidirectional=True,
+            batch_first=True,
+        )
+        self.fc = nn.Linear(self.hidden_dim, self.tagset_size)
+        self.crf = CRF(self.tagset_size)
+
+    def _to_tensor(self, arr: Any, dtype: torch.dtype = torch.long) -> torch.Tensor:
+        if isinstance(arr, torch.Tensor):
+            return arr.to(dtype)
+        if isinstance(arr, np.ndarray):
+            return torch.from_numpy(arr).to(dtype)
+        raise TypeError("Input must be a torch.Tensor or numpy.ndarray")
+
+    def _forward(self, X: torch.Tensor) -> torch.Tensor:
+        x = self.embed(X)
+        x, _ = self.lstm(x)
+        emissions = self.fc(x)
+        return emissions
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_t = self._to_tensor(X)
+        y_t = self._to_tensor(y)
+        optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
+        mask = torch.ones_like(X_t, dtype=torch.bool)
+        self.train()
+        for _ in range(self.epochs):
+            optimizer.zero_grad()
+            emissions = self._forward(X_t)
+            loss = -self.crf(emissions, y_t, mask).mean()
+            loss.backward()
+            optimizer.step()
+
+    def predict(self, X: Any) -> torch.Tensor:
+        X_t = self._to_tensor(X)
+        self.eval()
+        mask = torch.ones_like(X_t, dtype=torch.bool)
+        with torch.no_grad():
+            emissions = self._forward(X_t)
+            preds = self.crf.viterbi_decode(emissions, mask)
+        return torch.tensor(preds)
+
+    def save(self, path: str) -> None:
+        torch.save(
+            {
+                "state_dict": self.state_dict(),
+                "config": {
+                    "vocab_size": self.vocab_size,
+                    "tagset_size": self.tagset_size,
+                    "embedding_dim": self.embedding_dim,
+                    "hidden_dim": self.hidden_dim,
+                    "lr": self.lr,
+                    "epochs": self.epochs,
+                },
+            },
+            path,
+        )
+
+    def load(self, path: str) -> None:
+        data = torch.load(path, map_location="cpu")
+        cfg = data.get("config", {})
+        self.__init__(
+            cfg.get("vocab_size", 1),
+            cfg.get("tagset_size", 1),
+            cfg.get("embedding_dim", self.embedding_dim),
+            cfg.get("hidden_dim", self.hidden_dim),
+            cfg.get("lr", self.lr),
+            cfg.get("epochs", self.epochs),
+        )
+        self.load_state_dict(data["state_dict"])

--- a/tensorus/models/word2vec_model.py
+++ b/tensorus/models/word2vec_model.py
@@ -1,0 +1,48 @@
+import numpy as np
+from typing import Iterable, List, Optional
+from gensim.models import Word2Vec
+import joblib
+
+from .base import TensorusModel
+
+
+class Word2VecModel(TensorusModel):
+    """Word2Vec embeddings using ``gensim.models.Word2Vec``."""
+
+    def __init__(
+        self,
+        vector_size: int = 50,
+        window: int = 5,
+        min_count: int = 1,
+        epochs: int = 5,
+        **kwargs: any,
+    ) -> None:
+        self.vector_size = int(vector_size)
+        self.window = int(window)
+        self.min_count = int(min_count)
+        self.epochs = int(epochs)
+        self.kwargs = kwargs
+        self.model: Optional[Word2Vec] = None
+
+    def fit(self, sentences: Iterable[List[str]], y: any = None) -> None:
+        self.model = Word2Vec(
+            sentences=list(sentences),
+            vector_size=self.vector_size,
+            window=self.window,
+            min_count=self.min_count,
+            epochs=self.epochs,
+            **self.kwargs,
+        )
+
+    def predict(self, tokens: List[str]) -> np.ndarray:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() first.")
+        return np.vstack([self.model.wv[token] for token in tokens])
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Model not trained. Call fit() before save().")
+        self.model.save(path)
+
+    def load(self, path: str) -> None:
+        self.model = Word2Vec.load(path)

--- a/tests/test_embedding_and_ner.py
+++ b/tests/test_embedding_and_ner.py
@@ -1,0 +1,54 @@
+import numpy as np
+import torch
+
+from tensorus.models.word2vec_model import Word2VecModel
+from tensorus.models.glove_model import GloVeModel
+from tensorus.models.named_entity_recognition import NamedEntityRecognitionModel
+
+
+def _get_corpus():
+    return [["hello", "world"], ["hello", "tensorus"]]
+
+
+def test_word2vec_training(tmp_path):
+    corpus = _get_corpus()
+    model = Word2VecModel(vector_size=10, window=2, min_count=1, epochs=20)
+    model.fit(corpus)
+    vec = model.predict(["hello"])
+    assert vec.shape == (1, 10)
+
+    save_path = tmp_path / "w2v.model"
+    model.save(str(save_path))
+    model2 = Word2VecModel()
+    model2.load(str(save_path))
+    assert np.allclose(model2.predict(["hello"]), vec)
+
+
+def test_glove_training(tmp_path):
+    corpus = _get_corpus()
+    model = GloVeModel(vector_size=10, window=2, iterations=5)
+    model.fit(corpus)
+    vec = model.predict(["hello"])
+    assert vec.shape == (1, 10)
+
+    save_path = tmp_path / "glove.joblib"
+    model.save(str(save_path))
+    model2 = GloVeModel(vector_size=10)
+    model2.load(str(save_path))
+    assert np.allclose(model2.predict(["hello"]), vec)
+
+
+def test_simple_ner_tagging():
+    sentences = np.array([[0, 1, 2], [2, 1, 0]])
+    tags = np.array([[1, 0, 1], [1, 0, 1]])
+    model = NamedEntityRecognitionModel(
+        vocab_size=3,
+        tagset_size=2,
+        embedding_dim=8,
+        hidden_dim=8,
+        lr=0.1,
+        epochs=100,
+    )
+    model.fit(sentences, tags)
+    preds = model.predict(sentences)
+    assert torch.equal(preds, torch.tensor(tags))


### PR DESCRIPTION
## Summary
- add Word2Vec embedding model using gensim
- implement a minimal GloVe model
- add a BiLSTM-CRF NamedEntityRecognitionModel
- test embedding training and simple NER tagging

## Testing
- `pytest tests/test_embedding_and_ner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68418305c5ec8331bd100a33eced22bd