### PR TITLE
Add neuro-symbolic and ensemble models

### DIFF
--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -85,6 +85,10 @@ from .unet_segmentation import UNetSegmentationModel
 from .collaborative_filtering import CollaborativeFilteringModel
 from .matrix_factorization import MatrixFactorizationModel
 from .neural_cf import NeuralCollaborativeFilteringModel
+from .neuro_symbolic_model import NeuroSymbolicModel
+from .physics_informed_nn import PhysicsInformedNNModel
+from .stacked_generalization import StackedGeneralizationModel
+from .mixture_of_experts import MixtureOfExpertsModel
 from .utils import load_xy_from_storage, store_predictions
 
 __all__ = [
@@ -151,6 +155,10 @@ __all__ = [
     "CollaborativeFilteringModel",
     "MatrixFactorizationModel",
     "NeuralCollaborativeFilteringModel",
+    "NeuroSymbolicModel",
+    "PhysicsInformedNNModel",
+    "StackedGeneralizationModel",
+    "MixtureOfExpertsModel",
     "LSTMModule",
     "GRUModule",
     "BidirectionalWrapper",
@@ -210,3 +218,7 @@ register_model("UNetSegmentation", UNetSegmentationModel)
 register_model("CollaborativeFiltering", CollaborativeFilteringModel)
 register_model("MatrixFactorization", MatrixFactorizationModel)
 register_model("NeuralCollaborativeFiltering", NeuralCollaborativeFilteringModel)
+register_model("NeuroSymbolic", NeuroSymbolicModel)
+register_model("PhysicsInformedNN", PhysicsInformedNNModel)
+register_model("StackedGeneralization", StackedGeneralizationModel)
+register_model("MixtureOfExperts", MixtureOfExpertsModel)

--- a/tensorus/models/mixture_of_experts.py
+++ b/tensorus/models/mixture_of_experts.py
@@ -1,0 +1,52 @@
+import numpy as np
+from typing import Any, List, Optional
+
+from .base import TensorusModel
+
+
+class MixtureOfExpertsModel(TensorusModel):
+    """Combine multiple experts using fixed weights."""
+
+    def __init__(self, models: List[TensorusModel], weights: Optional[List[float]] = None) -> None:
+        self.models = models
+        if weights is None:
+            weights = [1.0 / len(models)] * len(models)
+        self.weights = weights
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        for m in self.models:
+            m.fit(X, y)
+
+    def predict(self, X: Any) -> Any:
+        preds = []
+        for m in self.models:
+            p = m.predict(X)
+            preds.append(self._to_array(p))
+        avg = np.sum([w * p for w, p in zip(self.weights, preds)], axis=0)
+        first_pred = self.models[0].predict(X)
+        if isinstance(first_pred, np.ndarray):
+            return avg
+        else:
+            import torch
+            return torch.tensor(avg, dtype=first_pred.dtype)
+
+    def save(self, path: str) -> None:
+        import joblib
+        joblib.dump({"models": self.models, "weights": self.weights}, path)
+
+    def load(self, path: str) -> None:
+        import joblib
+        data = joblib.load(path)
+        self.models = data["models"]
+        self.weights = data["weights"]

--- a/tensorus/models/neuro_symbolic_model.py
+++ b/tensorus/models/neuro_symbolic_model.py
@@ -1,0 +1,29 @@
+import joblib
+from typing import Any, Callable, Optional
+
+from .base import TensorusModel
+
+
+class NeuroSymbolicModel(TensorusModel):
+    """Wrap a neural model with optional symbolic post-processing."""
+
+    def __init__(self, base_model: TensorusModel, symbolic_fn: Optional[Callable[[Any, Any], Any]] = None) -> None:
+        self.base_model = base_model
+        self.symbolic_fn = symbolic_fn
+
+    def fit(self, X: Any, y: Any) -> None:
+        self.base_model.fit(X, y)
+
+    def predict(self, X: Any) -> Any:
+        preds = self.base_model.predict(X)
+        if self.symbolic_fn is not None:
+            preds = self.symbolic_fn(X, preds)
+        return preds
+
+    def save(self, path: str) -> None:
+        joblib.dump({"base_model": self.base_model, "symbolic_fn": self.symbolic_fn}, path)
+
+    def load(self, path: str) -> None:
+        data = joblib.load(path)
+        self.base_model = data["base_model"]
+        self.symbolic_fn = data.get("symbolic_fn")

--- a/tensorus/models/physics_informed_nn.py
+++ b/tensorus/models/physics_informed_nn.py
@@ -1,0 +1,96 @@
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+import numpy as np
+from typing import Any, Callable, Optional, List
+
+from .base import TensorusModel
+
+
+class PhysicsInformedNNModel(TensorusModel):
+    """Simple feed-forward network with physics-informed loss."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_layers: Optional[List[int]] = None,
+        lr: float = 0.001,
+        epochs: int = 100,
+        batch_size: int = 32,
+        physics_loss_fn: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
+        physics_weight: float = 1.0,
+    ) -> None:
+        self.input_size = input_size
+        self.hidden_layers = hidden_layers or [32]
+        self.lr = lr
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.physics_loss_fn = physics_loss_fn
+        self.physics_weight = physics_weight
+        self._build_model()
+
+    def _build_model(self) -> None:
+        modules: List[nn.Module] = []
+        in_dim = self.input_size
+        for h in self.hidden_layers:
+            modules.append(nn.Linear(in_dim, h))
+            modules.append(nn.Tanh())
+            in_dim = h
+        modules.append(nn.Linear(in_dim, 1))
+        self.model = nn.Sequential(*modules).to("cpu")
+
+    def _to_tensor(self, arr: Any) -> torch.Tensor:
+        if isinstance(arr, torch.Tensor):
+            return arr.float()
+        if isinstance(arr, np.ndarray):
+            return torch.from_numpy(arr).float()
+        raise TypeError("Input must be a torch.Tensor or numpy.ndarray")
+
+    def fit(self, X: Any, y: Any) -> None:
+        X_t = self._to_tensor(X)
+        y_t = self._to_tensor(y).view(-1)
+        dataset = TensorDataset(X_t, y_t)
+        loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
+        opt = torch.optim.Adam(self.model.parameters(), lr=self.lr)
+        mse = nn.MSELoss()
+        for _ in range(self.epochs):
+            for xb, yb in loader:
+                xb = xb.requires_grad_(self.physics_loss_fn is not None)
+                opt.zero_grad()
+                pred = self.model(xb).view(-1)
+                loss = mse(pred, yb)
+                if self.physics_loss_fn is not None:
+                    phys = self.physics_loss_fn(xb, pred)
+                    loss = loss + self.physics_weight * phys
+                loss.backward()
+                opt.step()
+
+    def predict(self, X: Any) -> torch.Tensor:
+        X_t = self._to_tensor(X)
+        self.model.eval()
+        with torch.no_grad():
+            pred = self.model(X_t).view(-1)
+        return pred
+
+    def save(self, path: str) -> None:
+        torch.save({"state_dict": self.model.state_dict(),
+                    "config": {
+                        "input_size": self.input_size,
+                        "hidden_layers": self.hidden_layers,
+                        "lr": self.lr,
+                        "epochs": self.epochs,
+                        "batch_size": self.batch_size,
+                        "physics_weight": self.physics_weight,
+                    }}, path)
+
+    def load(self, path: str) -> None:
+        data = torch.load(path, map_location="cpu")
+        cfg = data.get("config", {})
+        self.input_size = cfg.get("input_size", self.input_size)
+        self.hidden_layers = cfg.get("hidden_layers", self.hidden_layers)
+        self.lr = cfg.get("lr", self.lr)
+        self.epochs = cfg.get("epochs", self.epochs)
+        self.batch_size = cfg.get("batch_size", self.batch_size)
+        self.physics_weight = cfg.get("physics_weight", self.physics_weight)
+        self._build_model()
+        self.model.load_state_dict(data["state_dict"])

--- a/tensorus/models/stacked_generalization.py
+++ b/tensorus/models/stacked_generalization.py
@@ -1,0 +1,45 @@
+import numpy as np
+from typing import Any, List
+
+from .base import TensorusModel
+
+
+class StackedGeneralizationModel(TensorusModel):
+    """Simple stacking ensemble using predictions of base models."""
+
+    def __init__(self, base_models: List[TensorusModel], meta_model: TensorusModel) -> None:
+        self.base_models = base_models
+        self.meta_model = meta_model
+
+    def _to_array(self, arr: Any) -> np.ndarray:
+        if isinstance(arr, np.ndarray):
+            return arr
+        try:
+            import torch
+            if isinstance(arr, torch.Tensor):
+                return arr.detach().cpu().numpy()
+        except Exception:
+            pass
+        raise TypeError("Input must be a numpy array or torch tensor")
+
+    def fit(self, X: Any, y: Any) -> None:
+        for model in self.base_models:
+            model.fit(X, y)
+        base_preds = [self._to_array(m.predict(X)).reshape(len(self._to_array(X)), -1) for m in self.base_models]
+        meta_X = np.hstack(base_preds)
+        self.meta_model.fit(meta_X, self._to_array(y))
+
+    def predict(self, X: Any) -> Any:
+        base_preds = [self._to_array(m.predict(X)).reshape(len(self._to_array(X)), -1) for m in self.base_models]
+        meta_X = np.hstack(base_preds)
+        return self.meta_model.predict(meta_X)
+
+    def save(self, path: str) -> None:
+        import joblib
+        joblib.dump({"base_models": self.base_models, "meta_model": self.meta_model}, path)
+
+    def load(self, path: str) -> None:
+        import joblib
+        data = joblib.load(path)
+        self.base_models = data["base_models"]
+        self.meta_model = data["meta_model"]

--- a/tests/test_meta_learning_models.py
+++ b/tests/test_meta_learning_models.py
@@ -1,0 +1,100 @@
+import importlib.util
+import types
+import sys
+from pathlib import Path
+import numpy as np
+import torch
+
+# Create lightweight package structure to avoid heavy dependencies
+tensorus_pkg = types.ModuleType("tensorus")
+models_pkg = types.ModuleType("tensorus.models")
+sys.modules.setdefault("tensorus", tensorus_pkg)
+sys.modules.setdefault("tensorus.models", models_pkg)
+
+ts_spec = importlib.util.spec_from_file_location(
+    "tensorus.tensor_storage",
+    Path(__file__).resolve().parents[1] / "tensorus" / "tensor_storage.py",
+)
+ts_mod = importlib.util.module_from_spec(ts_spec)
+ts_spec.loader.exec_module(ts_mod)  # type: ignore
+sys.modules["tensorus.tensor_storage"] = ts_mod
+
+base_path = Path(__file__).resolve().parents[1] / "tensorus" / "models"
+
+for mod_name in [
+    "base",
+    "linear_regression",
+    "logistic_regression",
+    "neuro_symbolic_model",
+    "physics_informed_nn",
+    "stacked_generalization",
+    "mixture_of_experts",
+]:
+    spec = importlib.util.spec_from_file_location(
+        f"tensorus.models.{mod_name}", base_path / f"{mod_name}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    sys.modules[f"tensorus.models.{mod_name}"] = module
+
+from tensorus.models.linear_regression import LinearRegressionModel
+from tensorus.models.logistic_regression import LogisticRegressionModel
+from tensorus.models.neuro_symbolic_model import NeuroSymbolicModel
+from tensorus.models.physics_informed_nn import PhysicsInformedNNModel
+from tensorus.models.stacked_generalization import StackedGeneralizationModel
+from tensorus.models.mixture_of_experts import MixtureOfExpertsModel
+
+
+def test_stacked_generalization_model():
+    X = np.array([[1.0], [2.0], [3.0], [4.0]])
+    y = np.array([3.0, 5.0, 7.0, 9.0])
+    base1 = LinearRegressionModel()
+    base2 = LinearRegressionModel()
+    meta = LinearRegressionModel()
+    model = StackedGeneralizationModel([base1, base2], meta)
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert torch.allclose(preds, torch.tensor(y, dtype=preds.dtype), atol=1e-4)
+
+
+def test_mixture_of_experts_model():
+    X = np.array([[1.0], [2.0], [3.0], [4.0]])
+    y = np.array([3.0, 5.0, 7.0, 9.0])
+    m1 = LinearRegressionModel()
+    m2 = LinearRegressionModel()
+    model = MixtureOfExpertsModel([m1, m2])
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert torch.allclose(preds, torch.tensor(y, dtype=preds.dtype), atol=1e-4)
+
+
+def test_neuro_symbolic_model():
+    X = np.array([[0.0], [1.0], [2.0], [3.0]])
+    y = np.array([0.0, 0.0, 1.0, 1.0])
+    base = LogisticRegressionModel(lr=0.5, epochs=1000)
+
+    def rule(X_in, preds_in):
+        x_np = np.asarray(X_in)
+        override = (x_np[:, 0] >= 1.5).astype(float)
+        if isinstance(preds_in, torch.Tensor):
+            return torch.tensor(override, dtype=preds_in.dtype)
+        return override
+
+    model = NeuroSymbolicModel(base, symbolic_fn=rule)
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert torch.equal(preds, torch.tensor([0.0, 0.0, 1.0, 1.0]))
+
+
+def test_physics_informed_nn_model():
+    X = np.array([[0.0], [1.0], [2.0], [3.0]], dtype=np.float32)
+    y = 2 * X[:, 0]
+
+    def phys_loss(xb, pred):
+        grad = torch.autograd.grad(pred.sum(), xb, create_graph=True)[0]
+        return ((grad.squeeze() - 2.0) ** 2).mean()
+
+    model = PhysicsInformedNNModel(input_size=1, epochs=200, physics_loss_fn=phys_loss)
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert preds.shape == y.shape


### PR DESCRIPTION
## Summary
- implement `NeuroSymbolicModel` for attaching symbolic hooks to neural models
- add `PhysicsInformedNNModel` with optional physics-based loss term
- create ensemble models `StackedGeneralizationModel` and `MixtureOfExpertsModel`
- register new models and expose them via `__all__`
- test stacking, mixture of experts and physics informed training

## Testing
- `PYTHONPATH=. pytest tests/test_meta_learning_models.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68418cdb40888331bc087a6f3717f74e