### PR TITLE
Add new advanced models

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,40 @@ preds = model.predict(X)
 model.save("rbm.pt")
 ```
 
+### LargeLanguageModelWrapper Usage
+
+```python
+from tensorus.models.large_language_model import LargeLanguageModelWrapper
+
+model = LargeLanguageModelWrapper(model_name="gpt2")
+text = model.generate(["Hello world"])[0]
+print(text)
+```
+
+### MultimodalFoundationModel Usage
+
+```python
+from PIL import Image
+from tensorus.models.multimodal_foundation import MultimodalFoundationModel
+
+img = Image.new("RGB", (224, 224))
+model = MultimodalFoundationModel()
+similarity = model.predict([img], ["a plain image"])
+```
+
+### FedAvgModel Usage Considerations
+
+```python
+import torch.nn as nn
+from tensorus.models.fedavg_model import FedAvgModel
+
+global_net = nn.Linear(10, 2)
+aggregator = FedAvgModel(global_net)
+
+# client_state_dicts would be collected from remote clients
+aggregator.fit(client_state_dicts)
+```
+
 ## Basic Tensor Operations
 
 This section details the core tensor manipulation functionalities provided by `tensor_ops.py`. These operations are designed to be robust, with built-in type and shape checking where appropriate.

--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -89,6 +89,9 @@ from .neuro_symbolic_model import NeuroSymbolicModel
 from .physics_informed_nn import PhysicsInformedNNModel
 from .stacked_generalization import StackedGeneralizationModel
 from .mixture_of_experts import MixtureOfExpertsModel
+from .large_language_model import LargeLanguageModelWrapper
+from .multimodal_foundation import MultimodalFoundationModel
+from .fedavg_model import FedAvgModel
 from .utils import load_xy_from_storage, store_predictions
 
 __all__ = [
@@ -180,6 +183,9 @@ __all__ = [
     "GPTModel",
     "T5Model",
     "VisionTransformerModel",
+    "LargeLanguageModelWrapper",
+    "MultimodalFoundationModel",
+    "FedAvgModel",
 ]
 
 # Register models in the simple registry for convenience
@@ -222,3 +228,6 @@ register_model("NeuroSymbolic", NeuroSymbolicModel)
 register_model("PhysicsInformedNN", PhysicsInformedNNModel)
 register_model("StackedGeneralization", StackedGeneralizationModel)
 register_model("MixtureOfExperts", MixtureOfExpertsModel)
+register_model("LargeLanguageModel", LargeLanguageModelWrapper)
+register_model("MultimodalFoundation", MultimodalFoundationModel)
+register_model("FedAvg", FedAvgModel)

--- a/tensorus/models/fedavg_model.py
+++ b/tensorus/models/fedavg_model.py
@@ -1,0 +1,33 @@
+import torch
+from typing import Any, List
+from torch import nn
+
+from .base import TensorusModel
+
+
+class FedAvgModel(TensorusModel):
+    """Federated averaging for a set of client models."""
+
+    def __init__(self, global_model: nn.Module) -> None:
+        self.global_model = global_model
+
+    def fit(self, client_state_dicts: List[dict[str, torch.Tensor]]) -> None:
+        """Aggregate ``client_state_dicts`` by averaging their parameters."""
+        if not client_state_dicts:
+            return
+        avg_state = {}
+        for key in client_state_dicts[0].keys():
+            avg_state[key] = torch.stack([sd[key].float() for sd in client_state_dicts]).mean(dim=0)
+        self.global_model.load_state_dict(avg_state)
+
+    def predict(self, X: Any) -> Any:
+        self.global_model.eval()
+        with torch.no_grad():
+            return self.global_model(X)
+
+    def save(self, path: str) -> None:
+        torch.save({"state_dict": self.global_model.state_dict()}, path)
+
+    def load(self, path: str) -> None:
+        data = torch.load(path, map_location="cpu")
+        self.global_model.load_state_dict(data["state_dict"])

--- a/tensorus/models/large_language_model.py
+++ b/tensorus/models/large_language_model.py
@@ -1,0 +1,55 @@
+import torch
+from typing import Any, List, Optional
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from .base import TensorusModel
+
+
+class LargeLanguageModelWrapper(TensorusModel):
+    """Load a pre-trained causal language model and expose generation APIs."""
+
+    def __init__(
+        self,
+        model_name: str = "gpt2",
+        lr: float = 1e-4,
+        epochs: int = 1,
+        device: Optional[str] = None,
+    ) -> None:
+        self.model_name = model_name
+        self.lr = lr
+        self.epochs = epochs
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = AutoModelForCausalLM.from_pretrained(model_name)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model.to(self.device)
+
+    def fit(self, texts: List[str]) -> None:
+        """Fine-tune the language model on ``texts``."""
+        enc = self.tokenizer(texts, return_tensors="pt", padding=True)
+        input_ids = enc["input_ids"].to(self.device)
+        optimizer = torch.optim.Adam(self.model.parameters(), lr=self.lr)
+        self.model.train()
+        for _ in range(self.epochs):
+            optimizer.zero_grad()
+            out = self.model(input_ids=input_ids, labels=input_ids)
+            out.loss.backward()
+            optimizer.step()
+
+    def generate(self, prompts: List[str], max_length: int = 50, **kwargs: Any) -> List[str]:
+        """Generate text continuations for each prompt."""
+        enc = self.tokenizer(prompts, return_tensors="pt", padding=True).to(self.device)
+        with torch.no_grad():
+            output = self.model.generate(**enc, max_length=max_length, **kwargs)
+        return self.tokenizer.batch_decode(output, skip_special_tokens=True)
+
+    def predict(self, prompts: List[str]) -> List[str]:  # type: ignore[override]
+        return self.generate(prompts)
+
+    def save(self, path: str) -> None:
+        self.model.save_pretrained(path)
+        self.tokenizer.save_pretrained(path)
+
+    def load(self, path: str) -> None:
+        self.model = AutoModelForCausalLM.from_pretrained(path)
+        self.tokenizer = AutoTokenizer.from_pretrained(path)
+        self.model.to(self.device)

--- a/tensorus/models/multimodal_foundation.py
+++ b/tensorus/models/multimodal_foundation.py
@@ -1,0 +1,66 @@
+import torch
+from typing import Any, List, Optional
+from transformers import CLIPModel, CLIPProcessor
+
+from .base import TensorusModel
+
+
+class MultimodalFoundationModel(TensorusModel):
+    """CLIP-like model aligning text and image representations."""
+
+    def __init__(
+        self,
+        model_name: str = "openai/clip-vit-base-patch32",
+        lr: float = 1e-4,
+        epochs: int = 1,
+        device: Optional[str] = None,
+    ) -> None:
+        self.model_name = model_name
+        self.lr = lr
+        self.epochs = epochs
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = CLIPModel.from_pretrained(model_name)
+        self.processor = CLIPProcessor.from_pretrained(model_name)
+        self.model.to(self.device)
+
+    def fit(self, images: List[Any], texts: List[str]) -> None:
+        """Fine-tune on paired ``images`` and ``texts``."""
+        inputs = self.processor(text=texts, images=images, return_tensors="pt", padding=True)
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        optimizer = torch.optim.Adam(self.model.parameters(), lr=self.lr)
+        self.model.train()
+        target = torch.arange(len(texts), device=self.device)
+        for _ in range(self.epochs):
+            optimizer.zero_grad()
+            out = self.model(**inputs)
+            loss_i = torch.nn.functional.cross_entropy(out.logits_per_image, target)
+            loss_t = torch.nn.functional.cross_entropy(out.logits_per_text, target)
+            loss = (loss_i + loss_t) / 2
+            loss.backward()
+            optimizer.step()
+
+    def encode_text(self, texts: List[str]) -> torch.Tensor:
+        inputs = self.processor(text=texts, return_tensors="pt", padding=True).to(self.device)
+        with torch.no_grad():
+            return self.model.get_text_features(**inputs)
+
+    def encode_image(self, images: List[Any]) -> torch.Tensor:
+        inputs = self.processor(images=images, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            return self.model.get_image_features(**inputs)
+
+    def predict(self, images: List[Any], texts: List[str]) -> torch.Tensor:
+        """Return similarity scores between ``images`` and ``texts``."""
+        inputs = self.processor(text=texts, images=images, return_tensors="pt", padding=True).to(self.device)
+        with torch.no_grad():
+            out = self.model(**inputs)
+        return out.logits_per_image
+
+    def save(self, path: str) -> None:
+        self.model.save_pretrained(path)
+        self.processor.save_pretrained(path)
+
+    def load(self, path: str) -> None:
+        self.model = CLIPModel.from_pretrained(path)
+        self.processor = CLIPProcessor.from_pretrained(path)
+        self.model.to(self.device)


### PR DESCRIPTION
## Summary
- implement `LargeLanguageModelWrapper` to load pretrained LMs
- add `MultimodalFoundationModel` for CLIP-style text-image alignment
- provide `FedAvgModel` for federated weight averaging
- register the new models
- document usage examples in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68418ff108b48331855db19f5e87f46b