### PR TITLE
Add YOLOv5 detector model

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ managing models directly within Tensorus. The framework consists of:
     * `MobileNetModel` - MobileNet CNN.
     * `EfficientNetModel` - EfficientNet CNN.
     * `FasterRCNNModel` - object detection with Faster R-CNN.
+    * `YOLOv5Detector` - object detection with YOLOv5.
     * `UNetSegmentationModel` - UNet image segmentation.
     * `CollaborativeFilteringModel` - classic collaborative filtering.
     * `MatrixFactorizationModel` - matrix factorization recommender.

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ lightgbm
 catboost
 gensim
 joblib
+opencv-python

--- a/tensorus/models/__init__.py
+++ b/tensorus/models/__init__.py
@@ -82,6 +82,7 @@ from .gat_classifier import GATClassifierModel
 from .named_entity_recognition import NamedEntityRecognitionModel
 from .faster_rcnn import FasterRCNNModel
 from .unet_segmentation import UNetSegmentationModel
+from .yolov5_detector import YOLOv5Detector
 from .collaborative_filtering import CollaborativeFilteringModel
 from .matrix_factorization import MatrixFactorizationModel
 from .neural_cf import NeuralCollaborativeFilteringModel
@@ -154,6 +155,7 @@ __all__ = [
     "MobileNetModel",
     "EfficientNetModel",
     "FasterRCNNModel",
+    "YOLOv5Detector",
     "UNetSegmentationModel",
     "CollaborativeFilteringModel",
     "MatrixFactorizationModel",
@@ -231,6 +233,7 @@ register_model("Word2Vec", Word2VecModel)
 register_model("GloVe", GloVeModel)
 register_model("NamedEntityRecognition", NamedEntityRecognitionModel)
 register_model("FasterRCNN", FasterRCNNModel)
+register_model("YOLOv5", YOLOv5Detector)
 register_model("UNetSegmentation", UNetSegmentationModel)
 register_model("CollaborativeFiltering", CollaborativeFilteringModel)
 register_model("MatrixFactorization", MatrixFactorizationModel)

--- a/tensorus/models/yolov5_detector.py
+++ b/tensorus/models/yolov5_detector.py
@@ -1,0 +1,41 @@
+import torch
+import numpy as np
+from typing import Any
+
+from .base import TensorusModel
+
+
+class YOLOv5Detector(TensorusModel):
+    """YOLOv5 object detector loaded via PyTorch Hub."""
+
+    def __init__(self, model_name: str = "yolov5n", pretrained: bool = True, epochs: int = 1) -> None:
+        self.model = torch.hub.load("ultralytics/yolov5", model_name, pretrained=pretrained)
+        self.epochs = epochs
+
+    def _to_tensor(self, arr: Any) -> torch.Tensor:
+        if isinstance(arr, torch.Tensor):
+            return arr.float()
+        if isinstance(arr, np.ndarray):
+            return torch.from_numpy(arr).float()
+        raise TypeError("Input must be a torch.Tensor or numpy.ndarray")
+
+    def train(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - delegates to hub
+        """Thin wrapper around ``YOLOv5`` training."""
+        if hasattr(self.model, "train"):
+            self.model.train(*args, epochs=self.epochs, **kwargs)
+        else:
+            raise NotImplementedError("Training not supported for this model")
+
+    def predict(self, X: Any):
+        X_t = self._to_tensor(X)
+        if X_t.ndim == 3:
+            X_t = X_t.unsqueeze(0)
+        results = self.model(X_t)
+        return results
+
+    def save(self, path: str) -> None:
+        torch.save({"state_dict": self.model.model.state_dict()}, path)
+
+    def load(self, path: str) -> None:
+        data = torch.load(path, map_location="cpu")
+        self.model.model.load_state_dict(data["state_dict"])

--- a/tests/test_yolov5_detector.py
+++ b/tests/test_yolov5_detector.py
@@ -1,0 +1,44 @@
+import torch
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+# Dynamic import to avoid loading full package on test start
+pkg = types.ModuleType("tensorus")
+models_pkg = types.ModuleType("tensorus.models")
+sys.modules.setdefault("tensorus", pkg)
+sys.modules.setdefault("tensorus.models", models_pkg)
+
+base_spec = importlib.util.spec_from_file_location(
+    "tensorus.models.base",
+    Path(__file__).resolve().parents[1] / "tensorus" / "models" / "base.py",
+)
+base_mod = importlib.util.module_from_spec(base_spec)
+base_spec.loader.exec_module(base_mod)  # type: ignore
+sys.modules["tensorus.models.base"] = base_mod
+
+spec_yolo = importlib.util.spec_from_file_location(
+    "tensorus.models.yolov5_detector",
+    Path(__file__).resolve().parents[1] / "tensorus" / "models" / "yolov5_detector.py",
+)
+yolov5_mod = importlib.util.module_from_spec(spec_yolo)
+spec_yolo.loader.exec_module(yolov5_mod)  # type: ignore
+sys.modules["tensorus.models.yolov5_detector"] = yolov5_mod
+
+YOLOv5Detector = yolov5_mod.YOLOv5Detector
+
+
+def test_yolov5_predict(tmp_path):
+    model = YOLOv5Detector(model_name="yolov5n", pretrained=False)
+    img = torch.zeros(3, 32, 32)
+    model.train()  # ensure method exists
+    results = model.predict(img)
+    assert hasattr(results, "xyxy")
+
+    save_path = tmp_path / "yolo.pt"
+    model.save(save_path)
+    model2 = YOLOv5Detector(model_name="yolov5n", pretrained=False)
+    model2.load(save_path)
+    preds2 = model2.predict(img)
+    assert hasattr(preds2, "xyxy")


### PR DESCRIPTION
## Summary
- implement `YOLOv5Detector` model using torch hub
- register the new model
- mention it in the README
- add OpenCV to requirements
- create basic unit test for prediction and serialization

## Testing
- `./setup.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorus')*

------
https://chatgpt.com/codex/tasks/task_e_68419eb53a0483318e6fd8af83f1717d