### PR TITLE
Implement fit for YOLOv5Detector

### DIFF
--- a/tests/test_yolov5_detector.py
+++ b/tests/test_yolov5_detector.py
@@ -10,6 +10,21 @@ models_pkg = types.ModuleType("tensorus.models")
 sys.modules.setdefault("tensorus", pkg)
 sys.modules.setdefault("tensorus.models", models_pkg)
 
+storage_spec = importlib.util.spec_from_file_location(
+    "tensorus.tensor_storage",
+    Path(__file__).resolve().parents[1] / "tensorus" / "tensor_storage.py",
+)
+storage_mod = importlib.util.module_from_spec(storage_spec)
+storage_spec.loader.exec_module(storage_mod)  # type: ignore
+sys.modules["tensorus.tensor_storage"] = storage_mod
+
+# Provide a dummy OpenCV module to satisfy YOLOv5 imports
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+# Additional lightweight stubs for optional dependencies
+sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+sys.modules.setdefault("ultralytics", types.ModuleType("ultralytics"))
+
 base_spec = importlib.util.spec_from_file_location(
     "tensorus.models.base",
     Path(__file__).resolve().parents[1] / "tensorus" / "models" / "base.py",
@@ -32,7 +47,7 @@ YOLOv5Detector = yolov5_mod.YOLOv5Detector
 def test_yolov5_predict(tmp_path):
     model = YOLOv5Detector(model_name="yolov5n", pretrained=False)
     img = torch.zeros(3, 32, 32)
-    model.train()  # ensure method exists
+    model.fit(None)
     results = model.predict(img)
     assert hasattr(results, "xyxy")
 


### PR DESCRIPTION
## Summary
- implement `fit` for `YOLOv5Detector` and provide a lightweight fallback when
  dependencies are missing
- load minimal stubs in the YOLOv5 test and call `fit`

## Testing
- `pytest -q tests/test_yolov5_detector.py`
- `pytest -q` *(fails: ModuleNotFoundError for other modules)*

------
https://chatgpt.com/codex/tasks/task_e_6841e322edb8833189e47b3922904155