### PR TITLE
Implement inference-only fit for vision models

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,9 +417,9 @@ managing models directly within Tensorus. The framework consists of:
     * `ResNetModel` - ResNet CNN.
     * `MobileNetModel` - MobileNet CNN.
     * `EfficientNetModel` - EfficientNet CNN.
-    * `FasterRCNNModel` - object detection with Faster R-CNN.
+    * `FasterRCNNModel` - object detection with Faster R-CNN (inference only).
     * `YOLOv5Detector` - object detection with YOLOv5.
-    * `UNetSegmentationModel` - UNet image segmentation.
+    * `UNetSegmentationModel` - UNet image segmentation (inference only).
     * `CollaborativeFilteringModel` - classic collaborative filtering.
     * `MatrixFactorizationModel` - matrix factorization recommender.
     * `NeuralCollaborativeFilteringModel` - neural collaborative filtering.

--- a/tensorus/models/faster_rcnn.py
+++ b/tensorus/models/faster_rcnn.py
@@ -37,7 +37,10 @@ class FasterRCNNModel(TensorusModel):
         raise TypeError("Input must be a torch.Tensor or numpy.ndarray")
 
     def fit(self, X: Any, y: Any) -> None:  # pragma: no cover - training not implemented
-        pass
+        """Training is not supported for this model."""
+        raise NotImplementedError(
+            "FasterRCNNModel currently supports inference only"
+        )
 
     def predict(self, X: Any) -> List[Dict[str, torch.Tensor]]:
         X_t = self._to_tensor(X)

--- a/tensorus/models/unet_segmentation.py
+++ b/tensorus/models/unet_segmentation.py
@@ -36,7 +36,10 @@ class UNetSegmentationModel(TensorusModel):
         raise TypeError("Input must be a torch.Tensor or numpy.ndarray")
 
     def fit(self, X: Any, y: Any) -> None:  # pragma: no cover - training not implemented
-        pass
+        """Training is not supported for this model."""
+        raise NotImplementedError(
+            "UNetSegmentationModel currently supports inference only"
+        )
 
     def predict(self, X: Any) -> torch.Tensor:
         X_t = self._to_tensor(X)


### PR DESCRIPTION
## Summary
- show that certain models support only inference
- note inference-only in docs

## Testing
- `./setup.sh` *(fails: Running pip operations and install)*
- `pytest -q` *(fails to collect tests: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6841e4e01f34833184ade72e0e39e463