### PR TITLE
Rename custom ValidationError

### DIFF
--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -40,8 +40,8 @@ class NotFoundError(APIError):
     def __init__(self, detail: str = "Resource not found"):
         super().__init__(status_code=404, detail=detail)
 
-class ValidationError(APIError):
-    def __init__(self, detail: str = "Validation error"):
+class BadRequestError(APIError):
+    def __init__(self, detail: str = "Bad request"):
         super().__init__(status_code=400, detail=detail)
 
 # Custom middleware for logging


### PR DESCRIPTION
## Summary
- rename custom `ValidationError` exception to `BadRequestError`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6842a43829188331851e2213f2f038a2