### PR TITLE
Fix duplicated logging config

### DIFF
--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -107,9 +107,6 @@ if TYPE_CHECKING:
     # Import for type checking only to avoid heavy dependency during runtime
     from .ingestion_agent import DataIngestionAgent
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger = logging.getLogger(__name__)
 
 # --- Global Tensorus Instances ---
 try:


### PR DESCRIPTION
## Summary
- remove redundant `logging.basicConfig` invocation in `tensorus/api.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6842a57233a08331b88d4609b75d4101