### PR TITLE
Fix: Resolve NameError for 'app' in tensorus/api.py

### DIFF
--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -29,6 +29,28 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# --- FastAPI App Instance ---
+app = FastAPI(
+    title="Tensorus API",
+    description=(
+        "API for interacting with the Tensorus Agentic Tensor Database/Data Lake. "
+        "Includes dataset management, NQL querying, and agent control."
+    ),
+    version="0.2.1",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
+    # contact={
+    #     "name": "API Support",
+    #     "url": "http://example.com/support",
+    #     "email": "support@example.com",
+    # },
+    # license_info={
+    #     "name": "Apache 2.0",
+    #     "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+    # }
+)
+
 # Custom exceptions
 class APIError(Exception):
     def __init__(self, status_code: int, detail: str):
@@ -513,28 +535,6 @@ class DashboardMetrics(BaseModel):
     automl_trials_completed: int = Field(..., description="Simulated number of AutoML trials completed.")
     system_cpu_usage_percent: float = Field(..., description="Simulated overall system CPU usage percentage.")
     system_memory_usage_percent: float = Field(..., description="Simulated overall system memory usage percentage.")
-
-# --- FastAPI App Instance ---
-app = FastAPI(
-    title="Tensorus API",
-    description=(
-        "API for interacting with the Tensorus Agentic Tensor Database/Data Lake. "
-        "Includes dataset management, NQL querying, and agent control."
-    ),
-    version="0.2.1",
-    docs_url="/docs",
-    redoc_url="/redoc",
-    openapi_url="/openapi.json",
-    # contact={
-    #     "name": "API Support",
-    #     "url": "http://example.com/support",
-    #     "email": "support@example.com",
-    # },
-    # license_info={
-    #     "name": "Apache 2.0",
-    #     "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
-    # }
-)
 
 # Add middleware
 app.add_middleware(LoggingMiddleware)

--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -21,14 +21,6 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, root_validator, ValidationError
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
-# Configure structured logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler()]
-)
-logger = logging.getLogger(__name__)
-
 # --- FastAPI App Instance ---
 app = FastAPI(
     title="Tensorus API",
@@ -50,6 +42,14 @@ app = FastAPI(
     #     "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
     # }
 )
+
+# Configure structured logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[logging.StreamHandler()]
+)
+logger = logging.getLogger(__name__)
 
 # Custom exceptions
 class APIError(Exception):


### PR DESCRIPTION
The FastAPI application instance `app` was initialized after its first usage in `@app.on_event` decorators. This caused a `NameError` when Uvicorn attempted to load the application.

This commit moves the `app = FastAPI(...)` initialization block to an earlier point in the script, ensuring `app` is defined before any decorators, middleware, or routers reference it.