### PR TITLE
Remove unused storage_instance and clean imports

### DIFF
--- a/tensorus/metadata/storage.py
+++ b/tensorus/metadata/storage.py
@@ -1,17 +1,14 @@
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Any
 from uuid import UUID
 
 from .schemas import (
     TensorDescriptor, SemanticMetadata,
     LineageMetadata, ComputationalMetadata, QualityMetadata,
     RelationalMetadata, UsageMetadata,
-    TensorDescriptor # For search results
 )
 from .storage_abc import MetadataStorage
-from .schemas_iodata import TensorusExportData, TensorusExportEntry # Import I/O schemas
+from .schemas_iodata import TensorusExportData, TensorusExportEntry
 import copy
-from uuid import UUID # Ensure UUID is imported for type hints if not already
-from typing import List, Optional, Dict, Any # Ensure these are imported for type hints
 
 # In-memory storage using dictionaries
 _tensor_descriptors: Dict[UUID, TensorDescriptor] = {}
@@ -715,10 +712,3 @@ class InMemoryStorage(MetadataStorage): # Inherit from MetadataStorage
                 break
 
         return complex_tensors
-
-
-# Global instance of the storage
-# This makes it easy to use across different parts of an application (if simple)
-# For more complex scenarios, dependency injection or a more robust service locator pattern would be better.
-# For more complex scenarios, dependency injection or a more robust service locator pattern would be better.
-storage_instance = InMemoryStorage()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 # Import the FastAPI app instance
 from tensorus.api.main import app
 # Import the metadata storage instance that the API uses
-from tensorus.metadata.storage import storage_instance as metadata_storage_instance
+from tensorus.metadata import storage_instance as metadata_storage_instance
 # Import the mock tensor connector instance that the API uses
 from tensorus.storage.connectors import mock_tensor_connector_instance
 


### PR DESCRIPTION
## Summary
- remove redundant imports in `storage.py`
- drop unused `storage_instance` global
- update tests to import storage instance from package root

## Testing
- `pytest tests/test_config.py::test_settings_default_values -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684678ad9c908331b234d41284d81839