### PR TITLE
Fix optional models import

### DIFF
--- a/tensorus/__init__.py
+++ b/tensorus/__init__.py
@@ -1,7 +1,18 @@
 """Tensorus core package."""
 
-# The repository previously exposed a large collection of models under
-# ``tensorus.models``. These models have been removed, so the package no
-# longer attempts to import them on initialization.
+import os
 
-__all__: list[str] = []
+# The repository previously exposed a large collection of models under
+# ``tensorus.models``. These models have been moved to a separate package.
+# Tensorus now only attempts to import them if available.
+
+if not os.environ.get("TENSORUS_MINIMAL_IMPORT"):
+    try:
+        import importlib
+
+        models = importlib.import_module("tensorus.models")
+        __all__ = ["models"]
+    except ModuleNotFoundError:
+        __all__ = []
+else:
+    __all__ = []


### PR DESCRIPTION
## Summary
- optionally import `tensorus.models` if present

## Testing
- `pip install -r requirements-test.txt` *(fails: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6846ccc6cfa88331a83a384f23ea84df