### PR TITLE
Prune heavy model deps

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -136,7 +136,11 @@ This demo showcases the key capabilities of Tensorus, an agentic tensor database
 **Goal:** Demonstrate end-to-end time series forecasting using generated financial data, Tensorus for storage, an ARIMA model for prediction, and visualization within a dedicated UI page.
 
 **Prerequisites Specific to this Demo:**
-*   Ensure `statsmodels` is installed (it was added to `requirements.txt`). If you haven't updated dependencies: `pip install statsmodels>=0.13.0`.
+*   Ensure `statsmodels` is installed. If you used the standard setup, install it via the optional models extras:
+    ```bash
+    pip install -e .[models]
+    ```
+    or install the `tensorus-models` package which includes it.
 
 **Steps:**
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ graph TD
     `requirements-test.txt`, using CPU wheels for PyTorch and
     pinning `httpx` to a compatible version. The script also runs
     `npm install` in `mcp_tensorus_server` (needed for integration tests).
+    Heavy machine-learning libraries (e.g. `xgboost`, `lightgbm`, `catboost`,
+    `statsmodels`, `torch-geometric`) are not installed by default. Install
+    them separately using `pip install tensorus[models]` or by installing the
+    `tensorus-models` package if you need the built-in models.
 
 ### Running the API Server
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,6 +27,11 @@ The easiest way to get Tensorus and its PostgreSQL backend running locally is by
     ```bash
     pip install -r requirements.txt
     ```
+    Heavy machine-learning libraries used by the optional models are not
+    installed by default. Install them with the `[models]` extra when needed:
+    ```bash
+    pip install -e .[models]
+    ```
 5.  *(Optional)* Install the example models package. The built-in models that
     were previously part of this repository now live at
     [https://github.com/tensorus/models](https://github.com/tensorus/models):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,15 @@ classifiers = [
 Homepage = "https://tensorus.com"
 Repository = "https://github.com/tensorus/tensorus"
 
+[project.optional-dependencies]
+models = [
+    "torch-geometric",
+    "xgboost",
+    "lightgbm",
+    "catboost",
+    "statsmodels>=0.13.0"
+]
+
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,4 +6,3 @@ pytest-asyncio
 httpx==0.23.0
 scipy
 semopy>=2.3
-segmentation-models-pytorch

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 torch>=1.13.0
 torchvision>=0.14.0
 segmentation-models-pytorch
-torch-geometric
 transformers
 numpy>=1.21.0
 tensorly
@@ -40,16 +39,12 @@ httpx>=0.23.0 # For FastAPI TestClient
 # Optional: For plotting example in rl_agent.py
 matplotlib>=3.5.0
 # For Time Series Analysis (ARIMA model)
-statsmodels>=0.13.0
 scikit-learn>=1.3.0
 umap-learn
 pandas>=1.5.0
 arch>=5.7
 lifelines>=0.28
 semopy>=2.3
-xgboost
-lightgbm
-catboost
 gensim
 joblib
 opencv-python

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,10 @@ pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
 pip install -r requirements.txt
 pip install -r requirements-test.txt
 
+if [[ "$INSTALL_MODELS" == "1" ]]; then
+  pip install -e .[models]
+fi
+
 # Install Node.js dependencies for the MCP server (used in integration tests)
 pushd mcp_tensorus_server
 npm install


### PR DESCRIPTION
## Summary
- remove model-specific dependencies from default requirements
- add optional `[models]` extra
- note optional packages in installation docs and README
- update ARIMA demo instructions
- allow setup.sh to install optional models with `INSTALL_MODELS=1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorly')*


------
https://chatgpt.com/codex/tasks/task_e_6846d0cb0cdc8331b3cf928ec7855bfe