### PR TITLE
Add models extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,7 @@ Homepage = "https://tensorus.com"
 Repository = "https://github.com/tensorus/tensorus"
 
 [project.optional-dependencies]
-models = [
-    "torch-geometric",
-    "xgboost",
-    "lightgbm",
-    "catboost",
-    "statsmodels>=0.13.0"
-]
+models = ["tensorus-models>=0.0.3"]
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]


### PR DESCRIPTION
## Summary
- let `pip install 'tensorus[models]'` pull in the `tensorus-models` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: multiple test failures)*


------
https://chatgpt.com/codex/tasks/task_e_6846d3951874833191e987dcea8f9bbd