### PR TITLE
Fix config and security for Pydantic v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ graph TD
 *   FastAPI
 *   Uvicorn
 *   Streamlit
-*   Pydantic
+*   Pydantic v2
 *   Requests
 *   Pillow (for image preprocessing)
 *   Matplotlib (optional, for plotting RL rewards)
@@ -185,6 +185,8 @@ graph TD
     `statsmodels`, `torch-geometric`) are not installed by default. Install
     them separately using `pip install tensorus[models]` or by installing the
     `tensorus-models` package if you need the built-in models.
+    The audit logger writes to `tensorus_audit.log` by default. Override the
+    path with the `TENSORUS_AUDIT_LOG_PATH` environment variable if desired.
 
 ### Running the API Server
 

--- a/pydantic_settings.py
+++ b/pydantic_settings.py
@@ -1,4 +1,32 @@
-from pydantic import BaseSettings
-class SettingsConfigDict(dict):
-    pass
+"""Shim for pydantic-settings used during testing."""
+
+import importlib.util
+import site
+import sys
+from pathlib import Path
+import types
+
+_real_pkg = None
+for p in site.getsitepackages():
+    candidate = Path(p) / 'pydantic_settings' / '__init__.py'
+    if candidate.is_file() and candidate.resolve() != Path(__file__).resolve():
+        _real_pkg = candidate
+        break
+
+if _real_pkg:
+    spec = importlib.util.spec_from_file_location(
+        'pydantic_settings', str(_real_pkg),
+        submodule_search_locations=[str(Path(_real_pkg).parent)]
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    sys.modules['pydantic_settings'] = module
+    spec.loader.exec_module(module)  # type: ignore
+    BaseSettings = module.BaseSettings  # type: ignore
+    SettingsConfigDict = getattr(module, 'SettingsConfigDict', dict)
+else:
+    from pydantic import BaseSettings
+
+    class SettingsConfigDict(dict):
+        pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,9 @@ tensorly
 Pillow>=9.0.0
 
 # --- API Layer Dependencies ---
-fastapi>=0.90.0
-# Lock Pydantic < 2.0 for broad FastAPI compatibility, adjust if using newer FastAPI explicitly with Pydantic v2
-pydantic>=1.10.0,<2.0.0
+# FastAPI with Pydantic v2 support
+fastapi>=0.110.0
+pydantic>=2.0.0
 # ASGI Server (standard includes extras like watchfiles for reload)
 uvicorn[standard]>=0.20.0
 # For PostgreSQL connectivity (used by PostgresMetadataStorage)

--- a/tensorus/api/security.py
+++ b/tensorus/api/security.py
@@ -5,8 +5,20 @@ from typing import Optional, Dict, Any # Added Dict, Any for JWT payload
 
 from tensorus.config import settings
 
+
+class MutableAPIKeyHeader(APIKeyHeader):
+    """APIKeyHeader that allows updating the header name for testing."""
+
+    @property
+    def name(self) -> str:  # type: ignore[override]
+        return self.model.name
+
+    @name.setter
+    def name(self, value: str) -> None:  # type: ignore[override]
+        self.model.name = value
+
 # --- API Key Authentication ---
-api_key_header_auth = APIKeyHeader(name=settings.API_KEY_HEADER_NAME, auto_error=False)
+api_key_header_auth = MutableAPIKeyHeader(name=settings.API_KEY_HEADER_NAME, auto_error=False)
 
 async def verify_api_key(api_key: Optional[str] = Security(api_key_header_auth)):
     """

--- a/tensorus/audit.py
+++ b/tensorus/audit.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, Dict, Any
 import sys
+from tensorus.config import settings
 
 # Configure basic logger
 # In a real app, this might be more complex (e.g., JSON logging, log rotation, external service)
@@ -10,8 +11,7 @@ LOG_DEFAULT_HANDLERS = [logging.StreamHandler(sys.stdout)] # Log to stdout by de
 # Attempt to create a log file handler.
 # This is a simple file logger; in production, consider more robust solutions.
 try:
-    # TODO: Make log file path configurable via settings
-    file_handler = logging.FileHandler("tensorus_audit.log")
+    file_handler = logging.FileHandler(settings.AUDIT_LOG_PATH)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
     LOG_DEFAULT_HANDLERS.append(file_handler)
 except IOError:

--- a/tensorus/config.py
+++ b/tensorus/config.py
@@ -59,6 +59,7 @@ class SettingsV1(BaseSettings):
     # API Security
     VALID_API_KEYS: list[str] = [] # Comma-separated string in env, e.g., "key1,key2,key3"
     API_KEY_HEADER_NAME: str = "X-API-KEY"
+    AUDIT_LOG_PATH: str = "tensorus_audit.log"
 
 
     class Config:


### PR DESCRIPTION
## Summary
- support Pydantic v2 and newer FastAPI in requirements
- allow patching API key header name via `MutableAPIKeyHeader`
- make audit log path configurable
- document `TENSORUS_AUDIT_LOG_PATH`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings_pkg')*

------
https://chatgpt.com/codex/tasks/task_e_684707de8c4883318e9a5622381e3bbe