### PR TITLE
Update settings config

### DIFF
--- a/tensorus/config.py
+++ b/tensorus/config.py
@@ -65,7 +65,7 @@ class SettingsV1(BaseSettings):
 
 
 
-    model_config = SettingsConfigDict(env_prefix="TENSORUS_", case_sensitive=False, enable_decoding=False)
+    model_config = SettingsConfigDict(env_prefix="TENSORUS_", case_sensitive=False)
 
     @field_validator("VALID_API_KEYS", mode="before")
     def split_valid_api_keys(cls, v):


### PR DESCRIPTION
## Summary
- update `model_config` to use env prefix without `enable_decoding`
- adjust config tests for new environment parsing

## Testing
- `pytest tests/test_config.py::test_settings_from_env tests/test_config.py::test_settings_default_values tests/test_config.py::test_valid_api_keys_parsing_empty_env tests/test_config.py::test_valid_api_keys_json_list_in_env -q`
- `pytest -q` *(fails: expected call not found and validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847264514888331a0d06400e673fd1e