### PR TITLE
Fix audit log warning path

### DIFF
--- a/tensorus/audit.py
+++ b/tensorus/audit.py
@@ -16,7 +16,10 @@ try:
     LOG_DEFAULT_HANDLERS.append(file_handler)
 except IOError:
     # Handle cases where file cannot be opened (e.g. permissions)
-    print("Warning: Could not open tensorus_audit.log for writing. Audit logs will go to stdout only.", file=sys.stderr)
+    print(
+        f"Warning: Could not open {settings.AUDIT_LOG_PATH} for writing. Audit logs will go to stdout only.",
+        file=sys.stderr,
+    )
 
 
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, handlers=LOG_DEFAULT_HANDLERS)


### PR DESCRIPTION
## Summary
- use settings.AUDIT_LOG_PATH in the audit warning so the message shows the configured path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6847277092548331867a8e1031dd8014