### PR TITLE
Update Pydantic dict usage

### DIFF
--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -1449,8 +1449,8 @@ async def _store_and_respond_ops(
     default_metadata = {
         "operation": op_name,
         "timestamp": time.time(),
-        "source_tensors": [ref.dict() for ref in input_refs],
-        "source_api_request": request.dict(exclude_none=True) # Log the request for traceability
+        "source_tensors": [ref.model_dump() for ref in input_refs],
+        "source_api_request": request.model_dump(exclude_none=True)  # Log the request for traceability
     }
     final_metadata = {**default_metadata, **(request.output_metadata or {})}
 

--- a/tensorus/metadata/storage.py
+++ b/tensorus/metadata/storage.py
@@ -46,7 +46,7 @@ class InMemoryStorage(MetadataStorage): # Inherit from MetadataStorage
             # Create a new model instance with updated data to trigger Pydantic validation
             try:
                 # Get current data as dict
-                current_data = descriptor.dict() # or .model_dump() in Pydantic v2
+                current_data = descriptor.model_dump()
                 # Apply updates
                 updated_data = {**current_data, **kwargs}
 
@@ -191,7 +191,7 @@ class InMemoryStorage(MetadataStorage): # Inherit from MetadataStorage
         if not existing_metadata:
             return None
 
-        current_data = existing_metadata.dict() # Pydantic v1
+        current_data = existing_metadata.model_dump()
         updated_data = {**current_data, **kwargs}
 
         if 'tensor_id' in kwargs and UUID(kwargs['tensor_id']) != tensor_id:
@@ -266,7 +266,7 @@ class InMemoryStorage(MetadataStorage): # Inherit from MetadataStorage
         if not existing_metadata:
             return None
 
-        current_data = existing_metadata.dict() # Pydantic v1/v2: .model_dump()
+        current_data = existing_metadata.model_dump()
 
         # If 'access_history' is part of kwargs, it means we are modifying it.
         # The Pydantic model for UsageMetadata has validators that derive other fields from access_history.
@@ -286,7 +286,7 @@ class InMemoryStorage(MetadataStorage): # Inherit from MetadataStorage
             if key == "access_history" and isinstance(value, list):
                 # Ensure items in access_history are dicts for Pydantic validation
                 final_data_for_validation[key] = [
-                    item.dict() if hasattr(item, 'dict') else item
+                    item.model_dump() if hasattr(item, "model_dump") else item
                     for item in value
                 ]
             else:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -208,15 +208,13 @@ def test_usage_metadata_sync_validators():
     # Simple list append won't trigger it.
     # The current UsageMetadata validators are `always=True`, so they run on init/validate.
     # To test this properly, one might do:
-    um_revalidated = UsageMetadata.parse_obj(um.dict()) # Pydantic V1 way
-    # um_revalidated = UsageMetadata.model_validate(um.model_dump()) # Pydantic V2 way
+    um_revalidated = UsageMetadata.model_validate(um.model_dump())
 
     assert um_revalidated.usage_frequency == 1
     assert um_revalidated.last_accessed_at == t1
 
     um_revalidated.access_history.append(UsageAccessRecord(user_or_service="u2", operation_type="write", accessed_at=t2))
-    um_final = UsageMetadata.parse_obj(um_revalidated.dict()) # Pydantic V1
-    # um_final = UsageMetadata.model_validate(um_revalidated.model_dump()) # Pydantic V2
+    um_final = UsageMetadata.model_validate(um_revalidated.model_dump())
 
     assert um_final.usage_frequency == 2
     assert um_final.last_accessed_at == t2

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -67,7 +67,7 @@ def test_add_get_lineage_metadata(mem_storage: InMemoryStorage, base_td: TensorD
 def test_add_lineage_metadata_upsert(mem_storage: InMemoryStorage, base_td: TensorDescriptor, sample_lm: LineageMetadata):
     mem_storage.add_lineage_metadata(sample_lm) # First add
 
-    updated_lm_data = sample_lm.dict()
+    updated_lm_data = sample_lm.model_dump()
     updated_lm_data["version"] = "2.0"
     updated_lm = LineageMetadata(**updated_lm_data)
 
@@ -111,7 +111,7 @@ def test_add_get_computational_metadata(mem_storage: InMemoryStorage, base_td: T
 
 def test_add_computational_metadata_upsert(mem_storage: InMemoryStorage, base_td: TensorDescriptor, sample_cm: ComputationalMetadata):
     mem_storage.add_computational_metadata(sample_cm)
-    new_cm = ComputationalMetadata(**{**sample_cm.dict(), "algorithm": "RNN"})
+    new_cm = ComputationalMetadata(**{**sample_cm.model_dump(), "algorithm": "RNN"})
     mem_storage.add_computational_metadata(new_cm)
     retrieved = mem_storage.get_computational_metadata(base_td.tensor_id)
     assert retrieved is not None
@@ -148,7 +148,7 @@ def test_add_get_quality_metadata(mem_storage: InMemoryStorage, base_td: TensorD
 
 def test_add_quality_metadata_upsert(mem_storage: InMemoryStorage, base_td: TensorDescriptor, sample_qm: QualityMetadata):
     mem_storage.add_quality_metadata(sample_qm)
-    new_qm = QualityMetadata(**{**sample_qm.dict(), "noise_level": 0.1})
+    new_qm = QualityMetadata(**{**sample_qm.model_dump(), "noise_level": 0.1})
     mem_storage.add_quality_metadata(new_qm)
     retrieved = mem_storage.get_quality_metadata(base_td.tensor_id)
     assert retrieved is not None
@@ -186,7 +186,7 @@ def test_add_get_relational_metadata(mem_storage: InMemoryStorage, base_td: Tens
 
 def test_add_relational_metadata_upsert(mem_storage: InMemoryStorage, base_td: TensorDescriptor, sample_rm: RelationalMetadata):
     mem_storage.add_relational_metadata(sample_rm)
-    new_rm = RelationalMetadata(**{**sample_rm.dict(), "collections": ["setB"]})
+    new_rm = RelationalMetadata(**{**sample_rm.model_dump(), "collections": ["setB"]})
     mem_storage.add_relational_metadata(new_rm)
     retrieved = mem_storage.get_relational_metadata(base_td.tensor_id)
     assert retrieved is not None
@@ -225,7 +225,7 @@ def test_add_get_usage_metadata(mem_storage: InMemoryStorage, base_td: TensorDes
 def test_add_usage_metadata_upsert(mem_storage: InMemoryStorage, base_td: TensorDescriptor, sample_um: UsageMetadata):
     mem_storage.add_usage_metadata(sample_um)
     new_record = UsageAccessRecord(user_or_service="tester2", operation_type="write", accessed_at=datetime.utcnow())
-    new_um = UsageMetadata(**{**sample_um.dict(), "access_history": [new_record]})
+    new_um = UsageMetadata(**{**sample_um.model_dump(), "access_history": [new_record]})
     mem_storage.add_usage_metadata(new_um)
     retrieved = mem_storage.get_usage_metadata(base_td.tensor_id)
     assert retrieved is not None


### PR DESCRIPTION
## Summary
- use `model_dump()` instead of deprecated `dict()` on pydantic models
- adjust tests for `model_dump`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68473378047083319e6ac8073bc86a79