### PR TITLE
Add setup script and integration test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,12 @@ Tensorus includes Python unit tests and optional Node.js integration tests. To s
 
     This script installs packages from `requirements.txt` and `requirements-test.txt` and runs `npm install` in `mcp_tensorus_server`.
 
+    To install only the Node dependencies required for the integration tests, you can run the setup script inside the MCP server directory:
+
+    ```bash
+    ./mcp_tensorus_server/setup.sh
+    ```
+
 2. Run the Python test suite:
 
     ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,3 +71,18 @@ Tensorus is configured via environment variables. Key variables include:
 *   `TENSORUS_AUTH_DEV_MODE_ALLOW_DUMMY_JWT`: `True` to allow dummy JWTs for development if JWT auth is enabled (default `False`).
 
 Refer to the `docker-compose.yml` for example environment variable settings when running with Docker. For manual setup, export these variables in your shell or use a `.env` file (if your setup supports it, though direct environment variables are primary).
+
+## Running Tests
+
+Tensorus includes Python unit tests and optional Node.js integration tests. The Node-based tests depend on the MCP server's Node packages. Install them from the project root with:
+
+```bash
+./mcp_tensorus_server/setup.sh  # runs npm install inside mcp_tensorus_server
+```
+
+After installing dependencies, run the tests:
+
+```bash
+pytest
+cd mcp_tensorus_server && npm test
+```

--- a/mcp_tensorus_server/setup.sh
+++ b/mcp_tensorus_server/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Setup script for MCP Tensorus Server dependencies
+set -e
+npm install


### PR DESCRIPTION
## Summary
- add a small setup script under `mcp_tensorus_server` to install Node dependencies
- document the new script and npm install requirement for integration tests in README
- mention how to run tests in `docs/installation.md`

## Testing
- `./mcp_tensorus_server/setup.sh`
- `npm install`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `cd mcp_tensorus_server && npm test` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_68474ad6821083318ab3a63d49560c29