### PR TITLE
Add LLM rewrite logic tests

### DIFF
--- a/tests/test_api_query_llm.py
+++ b/tests/test_api_query_llm.py
@@ -1,0 +1,39 @@
+import os
+import importlib.util
+import pytest
+from unittest.mock import patch
+import torch
+
+from fastapi.testclient import TestClient
+
+spec = importlib.util.spec_from_file_location(
+    "tensorus.api_legacy",
+    os.path.join(os.path.dirname(__file__), "..", "tensorus", "api.py"),
+)
+api = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(api)
+from tensorus.nql_agent import NQLAgent
+from tensorus.tensor_storage import TensorStorage
+
+
+@pytest.fixture
+def client_with_llm(monkeypatch):
+    with patch("transformers.pipeline") as mock_root, patch("transformers.pipelines.pipeline") as mock_pipe:
+        mock_root.return_value = mock_pipe.return_value = lambda q: [{"generated_text": "get all data from test_ds"}]
+        storage = TensorStorage(storage_path=None)
+        storage.create_dataset("test_ds")
+        storage.insert("test_ds", torch.tensor([1.0]), metadata={"record_id": "r1"})
+        agent = NQLAgent(storage, use_llm=True)
+        monkeypatch.setattr(api, "nql_agent_instance", agent)
+        if hasattr(api.get_nql_agent, "_instance"):
+            monkeypatch.setattr(api.get_nql_agent, "_instance", agent, raising=False)
+        with TestClient(api.app) as client:
+            yield client
+
+
+def test_query_endpoint_with_llm_rewrite(client_with_llm):
+    resp = client_with_llm.post("/query", json={"query": "nonsense"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["count"] == 1

--- a/tests/test_nql_agent_llm.py
+++ b/tests/test_nql_agent_llm.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import patch
+import torch
+
+from tensorus.nql_agent import NQLAgent
+from tensorus.tensor_storage import TensorStorage
+
+@pytest.fixture
+def sample_storage():
+    storage = TensorStorage(storage_path=None)
+    storage.create_dataset("test_ds")
+    storage.insert("test_ds", torch.tensor([1.0]), metadata={"record_id": "r1"})
+    return storage
+
+
+def test_process_query_uses_llm_rewrite(sample_storage):
+    with patch("transformers.pipeline") as mock_root, patch("transformers.pipelines.pipeline") as mock_pipe:
+        mock_root.return_value = mock_pipe.return_value = lambda q: [{"generated_text": "get all data from test_ds"}]
+        agent = NQLAgent(sample_storage, use_llm=True)
+        with patch.object(agent, "_llm_rewrite_query", wraps=agent._llm_rewrite_query) as spy:
+            result = agent.process_query("unknown text")
+            assert spy.call_count == 1
+            assert result["success"]
+            assert result["count"] == 1
+
+
+def test_rewrite_stops_after_failure(sample_storage):
+    with patch("transformers.pipeline") as mock_root, patch("transformers.pipelines.pipeline") as mock_pipe:
+        mock_root.return_value = mock_pipe.return_value = lambda q: [{"generated_text": "still unsupported"}]
+        agent = NQLAgent(sample_storage, use_llm=True)
+        with patch.object(agent, "_llm_rewrite_query", wraps=agent._llm_rewrite_query) as spy:
+            result = agent.process_query("bad query")
+            assert spy.call_count == 1
+            assert not result["success"]


### PR DESCRIPTION
## Summary
- extend `NQLAgent` with optional LLM rewrite support
- call `_llm_rewrite_query` when queries fail to match
- add tests for LLM rewriting
- test `/query` endpoint with LLM enabled

## Testing
- `pytest tests/test_nql_agent_llm.py tests/test_api_query_llm.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848022bcfc083318f00b3d4d678dcc3