### PR TITLE
Add count method and NQLAgent update

### DIFF
--- a/tensorus/nql_agent.py
+++ b/tensorus/nql_agent.py
@@ -172,15 +172,12 @@ class NQLAgent:
             dataset_name = match.group(1)
             logger.debug(f"Matched COUNT pattern for dataset '{dataset_name}'")
             try:
-                # Inefficient: gets all data just to count.
-                # TODO: Add count method to TensorStorage
-                results = self.tensor_storage.get_dataset_with_metadata(dataset_name)
-                count = len(results)
+                count = self.tensor_storage.count(dataset_name)
                 return {
                     "success": True,
                     "message": f"Found {count} records in dataset '{dataset_name}'.",
                     "count": count,
-                    "results": None # Or optionally return all results if needed?
+                    "results": None  # Counting does not return full records
                 }
             except ValueError as e:
                 logger.error(f"Error during COUNT query: {e}")

--- a/tensorus/tensor_storage.py
+++ b/tensorus/tensor_storage.py
@@ -147,6 +147,24 @@ class TensorStorage:
             return file_path.exists()
         return False
 
+    def count(self, dataset_name: str) -> int:
+        """Return the number of tensors stored in a dataset.
+
+        Args:
+            dataset_name: The name of the dataset to count.
+
+        Returns:
+            int: Number of records in the dataset.
+
+        Raises:
+            DatasetNotFoundError: If the dataset does not exist.
+        """
+        if dataset_name not in self.datasets:
+            logging.error(f"Dataset '{dataset_name}' not found for count.")
+            raise DatasetNotFoundError(f"Dataset '{dataset_name}' does not exist.")
+
+        return len(self.datasets[dataset_name]["tensors"])
+
     def create_dataset(self, name: str, schema: Optional[Dict[str, Any]] = None) -> None:
         """
         Creates a new, empty dataset. Optionally associates a schema used for

--- a/tests/test_nql_agent_basic.py
+++ b/tests/test_nql_agent_basic.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+from unittest.mock import patch
+
+from tensorus.nql_agent import NQLAgent
+from tensorus.tensor_storage import TensorStorage
+
+@pytest.fixture
+def simple_storage():
+    storage = TensorStorage(storage_path=None)
+    storage.create_dataset("ds")
+    for i in range(2):
+        storage.insert("ds", torch.tensor([i]), metadata={"val": i})
+    return storage
+
+
+def test_count_query_uses_storage_count(simple_storage):
+    agent = NQLAgent(simple_storage)
+    with patch.object(simple_storage, "count", wraps=simple_storage.count) as spy:
+        result = agent.process_query("count records in ds")
+        assert result["success"]
+        assert result["count"] == 2
+        spy.assert_called_once_with("ds")
+
+
+def test_count_query_missing_dataset(simple_storage):
+    agent = NQLAgent(simple_storage)
+    result = agent.process_query("count records in missing_ds")
+    assert not result["success"]
+    assert result["count"] is None

--- a/tests/test_tensor_storage.py
+++ b/tests/test_tensor_storage.py
@@ -244,6 +244,16 @@ class TestTensorStorageInMemory(unittest.TestCase):
         with self.assertRaises(DatasetNotFoundError):
             self.storage.sample_dataset("non_existent_dataset", 1)
 
+    def test_count_dataset(self):
+        self.storage.create_dataset(self.dataset_name1)
+        for _ in range(3):
+            self.storage.insert(self.dataset_name1, torch.rand(2))
+
+        self.assertEqual(self.storage.count(self.dataset_name1), 3)
+
+        with self.assertRaises(DatasetNotFoundError):
+            self.storage.count("non_existent")
+
 
 class TestTensorStoragePersistent(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- implement `TensorStorage.count` to quickly count records in a dataset
- use `count` in `NQLAgent.process_query`
- add tests for the new method and query behaviour

## Testing
- `pytest tests/test_tensor_storage.py::TestTensorStorageInMemory::test_count_dataset tests/test_nql_agent_basic.py::test_count_query_uses_storage_count tests/test_nql_agent_basic.py::test_count_query_missing_dataset -q`

------
https://chatgpt.com/codex/tasks/task_e_684807bed1b08331a0f1f30a60db60c3