### PR TITLE
Add paginated dataset retrieval

### DIFF
--- a/pages/ui_utils.py
+++ b/pages/ui_utils.py
@@ -43,15 +43,15 @@ def list_datasets() -> Optional[List[str]]:
         logger.exception("Unexpected error in list_datasets")
         return None
 
-def fetch_dataset_data(dataset_name: str, max_records: int = 50) -> Optional[List[Dict[str, Any]]]:
-    """Fetches records from a dataset via API, limited after fetching."""
+def fetch_dataset_data(dataset_name: str, offset: int = 0, limit: int = 50) -> Optional[List[Dict[str, Any]]]:
+    """Fetches a page of records from a dataset via API."""
     try:
-        response = requests.get(f"{TENSORUS_API_URL}/datasets/{dataset_name}/fetch")
+        params = {"offset": offset, "limit": limit}
+        response = requests.get(f"{TENSORUS_API_URL}/datasets/{dataset_name}/records", params=params)
         response.raise_for_status()
         data = response.json()
         if data.get("success"):
-            all_records = data.get("data", [])
-            return all_records[:max_records] # Limit client-side for now
+            return data.get("data", [])
         else:
             st.error(f"API Error fetching '{dataset_name}': {data.get('message')}")
             return None

--- a/tensorus/tensor_storage.py
+++ b/tensorus/tensor_storage.py
@@ -444,6 +444,30 @@ class TensorStorage:
 
         return sampled_records
 
+    def get_records_paginated(self, name: str, offset: int = 0, limit: int = 100) -> List[Dict[str, Any]]:
+        """Retrieve a slice of records from a dataset.
+
+        Args:
+            name: Dataset name.
+            offset: Starting index of the slice.
+            limit: Maximum number of records to return.
+
+        Returns:
+            List of dictionaries each containing ``tensor`` and ``metadata``.
+
+        Raises:
+            DatasetNotFoundError: If the dataset does not exist.
+        """
+        if name not in self.datasets:
+            logging.error(f"Dataset '{name}' not found for pagination.")
+            raise DatasetNotFoundError(f"Dataset '{name}' does not exist.")
+
+        tensors = self.datasets[name]["tensors"]
+        metadata = self.datasets[name]["metadata"]
+        end = offset + limit if limit is not None else None
+        sliced = list(zip(tensors, metadata))[offset:end]
+        return [{"tensor": t, "metadata": m} for t, m in sliced]
+
     def delete_dataset(self, name: str) -> bool:
         """
         Deletes an entire dataset. Use with caution!

--- a/tests/test_dataset_api.py
+++ b/tests/test_dataset_api.py
@@ -1,0 +1,51 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("tensorus.api_local", Path(__file__).resolve().parents[1] / "tensorus" / "api.py")
+api_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(api_module)
+app = api_module.app
+tensor_storage_instance = api_module.tensor_storage_instance
+
+client = TestClient(app)
+TEST_DATASETS = set()
+
+def _cleanup():
+    for ds in list(TEST_DATASETS):
+        if tensor_storage_instance.dataset_exists(ds):
+            tensor_storage_instance.delete_dataset(ds)
+        TEST_DATASETS.discard(ds)
+
+@pytest.fixture(autouse=True)
+def cleanup_dataset():
+    yield
+    _cleanup()
+
+def _ingest(ds: str, value: int):
+    if not tensor_storage_instance.dataset_exists(ds):
+        client.post("/datasets/create", json={"name": ds})
+        TEST_DATASETS.add(ds)
+    payload = {"shape": [1], "dtype": "float32", "data": [float(value)], "metadata": {"v": value}}
+    resp = client.post(f"/datasets/{ds}/ingest", json=payload)
+    assert resp.status_code == 201
+    return resp.json()["data"]["record_id"]
+
+def test_records_pagination():
+    ds = "pag_api_ds"
+    ids = [_ingest(ds, i) for i in range(5)]
+
+    r1 = client.get(f"/datasets/{ds}/records", params={"offset":1, "limit":2})
+    assert r1.status_code == 200
+    data = r1.json()["data"]
+    assert len(data) == 2
+    assert data[0]["metadata"]["record_id"] == ids[1]
+
+    r2 = client.get(f"/datasets/{ds}/records", params={"offset":4, "limit":2})
+    assert r2.status_code == 200
+    assert len(r2.json()["data"]) == 1
+
+    r3 = client.get("/datasets/nonexistent/records")
+    assert r3.status_code == 404

--- a/tests/test_tensor_storage.py
+++ b/tests/test_tensor_storage.py
@@ -244,6 +244,22 @@ class TestTensorStorageInMemory(unittest.TestCase):
         with self.assertRaises(DatasetNotFoundError):
             self.storage.sample_dataset("non_existent_dataset", 1)
 
+    def test_get_records_paginated(self):
+        self.storage.create_dataset(self.dataset_name1)
+        ids = [self.storage.insert(self.dataset_name1, torch.tensor([i]), {"i": i}) for i in range(5)]
+
+        first_two = self.storage.get_records_paginated(self.dataset_name1, offset=0, limit=2)
+        self.assertEqual(len(first_two), 2)
+        self.assertEqual(first_two[0]["metadata"]["record_id"], ids[0])
+
+        next_two = self.storage.get_records_paginated(self.dataset_name1, offset=2, limit=2)
+        self.assertEqual(len(next_two), 2)
+        self.assertEqual(next_two[0]["metadata"]["record_id"], ids[2])
+
+        remaining = self.storage.get_records_paginated(self.dataset_name1, offset=4, limit=2)
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["metadata"]["record_id"], ids[4])
+
 
 class TestTensorStoragePersistent(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- implement `/datasets/{name}/records` API endpoint with `offset` and `limit`
- support pagination in TensorStorage
- fetch paginated data in Streamlit Data Explorer with navigation
- adjust UI utils for new endpoint
- add storage and API tests for pagination

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684808428c84833180d90d174fa4667a