### PR TITLE
Implement dataset count

### DIFF
--- a/tensorus/nql_agent.py
+++ b/tensorus/nql_agent.py
@@ -26,7 +26,7 @@ import logging
 import torch
 from typing import List, Dict, Any, Optional, Callable, Tuple
 
-from .tensor_storage import TensorStorage # Import our storage module
+from .tensor_storage import TensorStorage, DatasetNotFoundError
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -179,12 +179,12 @@ class NQLAgent:
                     "count": count,
                     "results": None  # Counting does not return full records
                 }
-            except ValueError as e:
+            except DatasetNotFoundError as e:
                 logger.error(f"Error during COUNT query: {e}")
                 return {"success": False, "message": str(e), "count": None, "results": None}
             except Exception as e:
-                 logger.error(f"Unexpected error during COUNT query: {e}", exc_info=True)
-                 return {"success": False, "message": f"An unexpected error occurred: {e}", "count": None, "results": None}
+                logger.error(f"Unexpected error during COUNT query: {e}", exc_info=True)
+                return {"success": False, "message": f"An unexpected error occurred: {e}", "count": None, "results": None}
 
 
         # --- 2. Get All Pattern ---

--- a/tests/test_dataset_count_api.py
+++ b/tests/test_dataset_count_api.py
@@ -1,0 +1,43 @@
+import os
+import importlib.util
+import pytest
+from fastapi.testclient import TestClient
+
+# Load the legacy api module which exposes dataset endpoints
+spec = importlib.util.spec_from_file_location(
+    "tensorus.api_legacy",
+    os.path.join(os.path.dirname(__file__), "..", "tensorus", "api.py"),
+)
+api = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(api)
+
+app = api.app
+storage = api.tensor_storage_instance
+
+@pytest.fixture(autouse=True)
+def clear_storage():
+    storage.datasets.clear()
+    yield
+    storage.datasets.clear()
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+def _ingest(client, dataset, value):
+    payload = {"shape": [1], "dtype": "float32", "data": [float(value)], "metadata": {"v": value}}
+    return client.post(f"/datasets/{dataset}/ingest", json=payload)
+
+
+def test_count_endpoint(client):
+    ds = "count_ds"
+    assert client.post("/datasets/create", json={"name": ds}).status_code == 201
+    _ingest(client, ds, 1)
+    _ingest(client, ds, 2)
+    resp = client.get(f"/datasets/{ds}/count")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["count"] == 2
+
+    resp_missing = client.get("/datasets/missing_ds/count")
+    assert resp_missing.status_code == 404


### PR DESCRIPTION
## Summary
- implement `TensorStorage.count` to load only metadata as needed
- use `DatasetNotFoundError` handling in NQLAgent count queries
- expose `/datasets/{name}/count` API
- add API tests for dataset counting

## Testing
- `pytest tests/test_dataset_count_api.py tests/test_nql_agent_basic.py tests/test_tensor_storage.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480fed092083318b99f83015770629