### PR TITLE
Update docs for /datasets/{name}/records

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -42,8 +42,8 @@ This demo showcases the key capabilities of Tensorus, an agentic tensor database
 5.  **Verify via API (Optional):**
     *   Use `curl` or Postman to fetch the tensor details. First, list datasets to find `ingested_data_api`, then fetch its records, identify the `record_id` for `cat.jpg` from its metadata.
         ```bash
-        # Example: List records in the dataset to find the ID
-        curl http://127.0.0.1:8000/datasets/ingested_data_api/fetch 
+        # Example: List records in the dataset to find the ID (paged)
+        curl "http://127.0.0.1:8000/datasets/ingested_data_api/records?offset=0&limit=100"
         # Then use the ID:
         # curl http://127.0.0.1:8000/datasets/ingested_data_api/tensors/{record_id_of_cat_jpg}
         ```

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ The API provides the following main endpoints:
     *   `POST /datasets/create`: Create a new dataset.
     *   `POST /datasets/{name}/ingest`: Ingest a tensor into a dataset.
     *   `GET /datasets/{name}/fetch`: Retrieve all records from a dataset.
+    *   `GET /datasets/{name}/records`: Retrieve a page of records. Supports `offset` (start index, default `0`) and `limit` (max results, default `100`).
     *   `GET /datasets`: List all available datasets.
 *   **Querying:**
     *   `POST /query`: Execute an NQL query.


### PR DESCRIPTION
## Summary
- document the new `/datasets/{name}/records` endpoint in the README
- update DEMO instructions to show paginated record retrieval

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684816dda1bc8331a3f98c90c4ea4a4e