### PR TITLE
Improve integration tests startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,10 @@ Tensorus includes Python unit tests and optional Node.js integration tests. To s
 
     This script installs packages from `requirements.txt` and `requirements-test.txt` and runs `npm install` in `mcp_tensorus_server`.
 
+    **Before running the integration tests ensure:**
+    * The Python dependencies are available in your active environment (activate the `.venv` created by `setup.sh` if using one).
+    * Port `8000` is free so the FastAPI server can bind to it.
+
     To install only the Node dependencies required for the integration tests, you can run the setup script inside the MCP server directory:
 
     ```bash


### PR DESCRIPTION
## Summary
- improve FastAPI startup reliability in integration tests by polling the `/health` endpoint
- add a short wait and longer Jest timeout to integration test file
- document integration test prerequisites in README

## Testing
- `pytest -q`
- `npm run test:integration`

------
https://chatgpt.com/codex/tasks/task_e_684b3ea4421483319bd2dac0d638c97e