### PR TITLE
Improve matrix_inverse precision

### DIFF
--- a/tensorus/tensor_ops.py
+++ b/tensorus/tensor_ops.py
@@ -508,7 +508,9 @@ class TensorOps:
             raise ValueError("Input matrix must be 2-D")
         if matrix.shape[0] != matrix.shape[1]:
             raise ValueError("Input matrix must be square")
-        return torch.linalg.inv(matrix)
+        orig_dtype = matrix.dtype
+        inv = torch.linalg.inv(matrix.double()).to(orig_dtype)
+        return inv
 
     @staticmethod
     def matrix_determinant(matrix: torch.Tensor) -> torch.Tensor:

--- a/tests/test_tensor_ops.py
+++ b/tests/test_tensor_ops.py
@@ -354,8 +354,7 @@ class TestTensorOps(unittest.TestCase):
         inv = TensorOps.matrix_inverse(A)
         expected_identity = torch.eye(2, dtype=torch.float32)
         actual_result = A @ inv
-        # print(f"Actual result (A @ inv):\n{actual_result}") # Optional: Keep for debugging if needed
-        # print(f"Expected identity:\n{expected_identity}") # Optional: Keep for debugging if needed
+        self.assertEqual(inv.dtype, A.dtype)
         self.assertTrue(torch.allclose(actual_result, expected_identity))
 
     def test_matrix_inverse_non_square_error(self):


### PR DESCRIPTION
## Summary
- compute `matrix_inverse` in float64 for better accuracy
- check dtype and accuracy in matrix inverse test

## Testing
- `pytest tests/test_tensor_ops.py::TestTensorOps::test_matrix_inverse -vv`
- `pytest tests/test_tensor_ops.py::TestTensorOps::test_matrix_inverse_non_square_error -vv`

------
https://chatgpt.com/codex/tasks/task_e_684be61505188331a84be95381bf9cb4