### PR TITLE
Add numpy to requirements-test

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,6 +9,7 @@ semopy>=2.3
 pydantic-settings>=2.0
 # FastAPI version supporting Pydantic v2
 fastapi>=0.110
+numpy>=1.21.0
 torch
 tensorly
 transformers


### PR DESCRIPTION
## Summary
- include numpy in `requirements-test.txt` for tests that import it

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: test_metadata_filtering)*

------
https://chatgpt.com/codex/tasks/task_e_684bfedf30148331a3136e59ec58c809