### PR TITLE
Pin FastAPI for tests

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,6 +32,12 @@ The easiest way to get Tensorus and its PostgreSQL backend running locally is by
     ```bash
     pip install -e .[models]
     ```
+    If you intend to run the test suite, also install the test requirements:
+    ```bash
+    pip install -r requirements-test.txt
+    ```
+    This ensures `fastapi>=0.110` is installed so the API is compatible with
+    Pydantic v2.
 5.  *(Optional)* Install the example models package. The built-in models that
     were previously part of this repository now live at
     [https://github.com/tensorus/models](https://github.com/tensorus/models):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,7 @@ httpx==0.23.0
 scipy
 semopy>=2.3
 pydantic-settings>=2.0
-# FastAPI version supporting Pydantic v2
+# FastAPI version supporting the Pydantic v2 API
 fastapi>=0.110
 numpy>=1.21.0
 torch


### PR DESCRIPTION
## Summary
- note the test requirements in the install docs
- clarify comment about the FastAPI version in requirements-test.txt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c007db4808331b0d501e41ec6a7b6