### PR TITLE
Fix numeric metadata comparison

### DIFF
--- a/tensorus/nql_agent.py
+++ b/tensorus/nql_agent.py
@@ -282,31 +282,23 @@ class NQLAgent:
                         return False  # Key doesn't exist in this record's metadata
 
                     # Handle comparisons where the filter value is numeric but the metadata value
-                    # might be stored as a non-numeric string (e.g. "N/A").  If the metadata string
-                    # cannot be converted to a number we only allow equality/inequality checks based
-                    # on the raw string representation.
-                    if isinstance(filter_value, (int, float)) and not isinstance(actual_value, (int, float)):
-                        if isinstance(actual_value, str):
-                            try:
-                                actual_numeric = float(actual_value)
-                                if actual_numeric.is_integer():
-                                    actual_numeric = int(actual_numeric)
-                                actual_value = actual_numeric
-                            except ValueError:
-                                # Metadata value is a non-numeric string
-                                if op_str in {"=", "==", "!="}:
-                                    return op_func(str(actual_value), str(filter_value))
-                                else:
-                                    return False
+                    # is stored as a string.  We do not coerce the string to a number to avoid
+                    # matching "007" with numeric 7.  Only equality/inequality comparisons are
+                    # permitted in this case using the raw string representations.
+                    if isinstance(filter_value, (int, float)) and isinstance(actual_value, str):
+                        if op_str in {"=", "==", "!="}:
+                            return op_func(str(actual_value), str(filter_value))
                         else:
-                            # Non-string metadata value that isn't numeric – attempt coercion
-                            try:
-                                actual_value = type(filter_value)(actual_value)
-                            except (ValueError, TypeError):
-                                if op_str in {"=", "==", "!="}:
-                                    return op_func(str(actual_value), str(filter_value))
-                                else:
-                                    return False
+                            return False
+                    elif isinstance(filter_value, (int, float)) and not isinstance(actual_value, (int, float)):
+                        # Non-string metadata value that isn't numeric – attempt coercion
+                        try:
+                            actual_value = type(filter_value)(actual_value)
+                        except (ValueError, TypeError):
+                            if op_str in {"=", "==", "!="}:
+                                return op_func(str(actual_value), str(filter_value))
+                            else:
+                                return False
 
                     # Attempt simple type coercion for remaining cases
                     try:


### PR DESCRIPTION
## Summary
- fix NQL Agent comparison logic when numeric filter is applied to string metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b461d2eac8331b50032e6b66d8169