### PR TITLE
Allow PYTHON_API_BASE_URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,10 @@ The Tensorus MCP Server is a Node.js application that acts as a bridge to the Py
 **Starting the MCP Server:**
 
 1.  Ensure the Python FastAPI backend is running.
-2.  From the `mcp_tensorus_server` directory, run:
+2.  Optionally set the `PYTHON_API_BASE_URL` environment variable if your
+    backend is running on a different host or port (default is
+    `http://127.0.0.1:8000`).
+3.  From the `mcp_tensorus_server` directory, run:
     ```bash
     node server.js
     ```
@@ -246,7 +249,7 @@ The Tensorus MCP Server is a Node.js application that acts as a bridge to the Py
     ```bash
     npm start
     ```
-3.  The MCP server will connect via stdio by default. MCP clients will communicate with this server process through its standard input and output.
+4.  The MCP server will connect via stdio by default. MCP clients will communicate with this server process through its standard input and output.
 ### Running the Python MCP Server
 
 Tensorus also provides a lightweight Python implementation of the Model Context Protocol server using `fastmcp`. It exposes the same FastAPI endpoints as tools so you can run an MCP server without Node.js.

--- a/mcp_tensorus_server/server.js
+++ b/mcp_tensorus_server/server.js
@@ -3,7 +3,9 @@ const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio
 const { ListToolsRequestSchema, CallToolRequestSchema } = require('@modelcontextprotocol/sdk/types.js');
 const axios = require('axios');
 
-const PYTHON_API_BASE_URL = 'http://127.0.0.1:8000'; // Ensure this matches your Python API server
+// Allow the Python API base URL to be overridden via an environment variable
+// while falling back to the default localhost value used throughout the docs.
+const PYTHON_API_BASE_URL = process.env.PYTHON_API_BASE_URL || 'http://127.0.0.1:8000';
 
 const UNARY_OPS = ["log", "reshape", "transpose", "permute", "sum", "mean", "min", "max"];
 const BINARY_OPS = ["add", "subtract", "multiply", "divide", "power", "matmul", "dot"];


### PR DESCRIPTION
## Summary
- allow setting `PYTHON_API_BASE_URL` via environment variable
- document the new variable in README
- integration test spawns MCP server with this variable and runs FastAPI using uvicorn

## Testing
- `pytest -q`
- `npm run test:integration` *(fails: Timed out waiting for Python API to become available)*

------
https://chatgpt.com/codex/tasks/task_e_684e08d902708331812f4e4f5f4da40d