### PR TITLE
Implement JWT validation via JWKS

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,3 +14,4 @@ torch
 tensorly
 transformers
 psycopg2-binary
+python-jose[cryptography]

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,8 @@ psycopg2-binary>=2.9.0
 streamlit>=1.25.0
 # For calling the FastAPI backend from the Streamlit UI
 requests>=2.28.0
+# For JWT validation
+python-jose[cryptography]
 # For plotting in the Streamlit UI (Dashboard, Data Explorer)
 plotly>=5.10.0
 


### PR DESCRIPTION
## Summary
- implement JWT verification using python-jose and JWKS
- log success or failure via audit logger
- ensure issuer and audience are read from configuration
- update tests for new JWT validation logic
- add `python-jose[cryptography]` dependency

## Testing
- `pytest tests/test_security.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e154d16688331a7b77c171cd04aa8