### PR TITLE
Clarify setup step and add test dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ If your system has NVIDIA GPUs and the [NVIDIA Container Toolkit](https://github
 
 ### Running Tests
 
-Tensorus includes Python unit tests and optional Node.js integration tests. To set up the environment and run them:
+Tensorus includes Python unit tests and optional Node.js integration tests. The tests require all Python and Node.js dependencies to be installed first. To set up the environment and run them:
 
 1. Install all dependencies using:
 
@@ -321,6 +321,7 @@ Tensorus includes Python unit tests and optional Node.js integration tests. To s
     ```
 
     This script installs packages from `requirements.txt` and `requirements-test.txt` (which pins `fastapi>=0.110` for Pydantic v2 support) and runs `npm install` in `mcp_tensorus_server`.
+    **You must run this script (or `./mcp_tensorus_server/setup.sh` for Node dependencies) before executing `pytest`, otherwise the pre-test check will exit with an error about missing packages.**
 
     **Before running the integration tests ensure:**
     * The Python dependencies are available in your active environment (activate the `.venv` created by `setup.sh` if using one).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,27 @@
+import importlib.util
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
+
+# ----- Pre-test dependency check -----
+missing = []
+for pkg in ("torch", "fastapi", "httpx"):
+    if importlib.util.find_spec(pkg) is None:
+        missing.append(pkg)
+
+if missing:
+    pytest.exit(
+        "Missing required packages: {}. Run ./setup.sh before running tests.".format(
+            ", ".join(missing)
+        ),
+        returncode=1,
+    )
+
+if not Path("mcp_tensorus_server/node_modules").exists():
+    print(
+        "Warning: Node.js dependencies not installed. Integration tests may fail. Run ./setup.sh or ./mcp_tensorus_server/setup.sh."
+    )
 
 # Import the FastAPI app instance
 from tensorus.api.main import app


### PR DESCRIPTION
## Summary
- document requirement to run `setup.sh` before running tests
- add pre-test dependency check in `conftest.py`

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5c1710f88331a2bccec8fca36bde