### PR TITLE
Update Dockerfile for HF Spaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,10 @@ ENV TENSORUS_AUTH_JWT_JWKS_URI=""
 ENV TENSORUS_AUTH_DEV_MODE_ALLOW_DUMMY_JWT="False"
 
 # Expose the port the app runs on
-EXPOSE 8000
+# Hugging Face Spaces expects the application to listen on port 7860
+EXPOSE 7860
 
 # Define the command to run the application
 # This assumes your FastAPI app instance is named 'app' in 'tensorus.api.main'
-CMD ["uvicorn", "tensorus.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run on port 7860 so the API is accessible in Docker based Spaces
+CMD ["uvicorn", "tensorus.api.main:app", "--host", "0.0.0.0", "--port", "7860"]


### PR DESCRIPTION
## Summary
- update Dockerfile to expose port 7860 and run UVicorn on that port

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_684f0be8d99883318783bfc10f48eade