### PR TITLE
Update httpx requirement

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@
 
 pytest
 pytest-asyncio
-httpx==0.23.0
+httpx>=0.28.1
 scipy
 semopy>=2.3
 pydantic-settings>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ plotly>=5.10.0
 
 # --- Testing Dependencies ---
 pytest>=7.0.0
-httpx>=0.23.0 # For FastAPI TestClient
+httpx>=0.28.1 # For FastAPI TestClient
 
 # --- Data Analysis & Modeling ---
 # Optional: For plotting example in rl_agent.py


### PR DESCRIPTION
## Summary
- bump `httpx` dependency to `>=0.28.1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastmcp')*

------
https://chatgpt.com/codex/tasks/task_e_684f2bb3abf08331b1e02fa7f92c8de9