### PR TITLE
Fix README duplicate heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ Tensorus includes a detailed metadata subsystem for describing tensors beyond th
 
 ### Streamlit UI
 
-### Streamlit UI
 
 The Streamlit UI provides a user-friendly interface for:
 


### PR DESCRIPTION
## Summary
- remove redundant "### Streamlit UI" heading from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2bd592308331af954a4782956642