### PR TITLE
Update default API URL

### DIFF
--- a/tensorus/mcp_server.py
+++ b/tensorus/mcp_server.py
@@ -21,7 +21,7 @@ except ImportError:  # pragma: no cover - support older fastmcp versions
         type: str
         text: str
 
-API_BASE_URL = "http://127.0.0.1:7860"
+API_BASE_URL = "https://tensorus-core.hf.space"
 
 server = FastMCP(name="Tensorus FastMCP")
 


### PR DESCRIPTION
## Summary
- update the default API base URL in `tensorus/mcp_server.py`

## Testing
- `pip install httpx`
- `pytest -q` *(fails: ImportError: cannot import name 'field_validator' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684fd4b844d08331ae55158b77ec7094