### PR TITLE
Update docs with HF URLs and new MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Run the container and expose the API server on port `7860`:
 docker run -p 7860:7860 tensorus
 ```
 
-The FastAPI documentation will then be available at `http://localhost:7860/docs`.
+The FastAPI documentation will then be available at `https://tensorus-core.hf.space/docs`.
 
 If your system has NVIDIA GPUs and the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) installed, you can pass `--gpus all` to `docker run` and modify `setup.sh` to install CUDA-enabled PyTorch wheels for GPU acceleration.
 
@@ -543,6 +543,10 @@ The Tensorus Model Context Protocol (MCP) Server allows external AI agents, LLM-
 
 The MCP server provides tools for various Tensorus functionalities. Below is an overview. For detailed input schemas and descriptions, an MCP client can call the standard `tools/list` method on the server, or you can inspect the tool definitions in `tensorus/mcp_server.py`.
 
+*   **General Utilities:**
+    *   `save_tensor`: Save a tensor to a dataset.
+    *   `get_tensor`: Retrieve a tensor by record ID.
+    *   `execute_nql_query`: Execute a Natural Query Language query.
 *   **Dataset Management:**
     *   `tensorus_list_datasets`: Lists all available datasets.
     *   `tensorus_create_dataset`: Creates a new dataset.
@@ -602,7 +606,7 @@ You can also interact with the server using the included Python helper:
 from tensorus.mcp_client import TensorusMCPClient
 
 async def example_py():
-    async with TensorusMCPClient("http://localhost:7860/sse") as client:
+    async with TensorusMCPClient("https://tensorus-core.hf.space/sse") as client:
         tools = await client.list_datasets()
         print(tools)
 ```

--- a/docs/api_guide.md
+++ b/docs/api_guide.md
@@ -4,9 +4,9 @@ The Tensorus Metadata System provides a comprehensive RESTful API for managing a
 
 ## Interactive API Documentation (Swagger UI)
 
-The API is self-documenting using OpenAPI. Once the application is running (e.g., locally at `http://localhost:7860`), you can access the interactive Swagger UI at:
+The API is self-documenting using OpenAPI. Once the application is running (e.g., at `https://tensorus-core.hf.space`), you can access the interactive Swagger UI at:
 
-*   **`/docs`**: [http://localhost:7860/docs](http://localhost:7860/docs)
+*   **`/docs`**: [https://tensorus-core.hf.space/docs](https://tensorus-core.hf.space/docs)
 
 This interface allows you to explore all available endpoints, view their request and response schemas, and even try out API calls directly from your browser.
 
@@ -14,7 +14,7 @@ This interface allows you to explore all available endpoints, view their request
 
 An alternative ReDoc interface is also available at:
 
-*   **`/redoc`**: [http://localhost:7860/redoc](http://localhost:7860/redoc)
+*   **`/redoc`**: [https://tensorus-core.hf.space/redoc](https://tensorus-core.hf.space/redoc)
 
 ## Main API Categories
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ The easiest way to get Tensorus and its PostgreSQL backend running locally is by
     ```bash
     docker-compose up --build
     ```
-4.  The API will typically be available at `http://localhost:7860`.
+4.  The API will typically be available at `https://tensorus-core.hf.space`.
 
 ### Manual Installation (From Source)
 


### PR DESCRIPTION
## Summary
- replace localhost references with tensorus-core.hf.space
- mention save_tensor, get_tensor, and execute_nql_query tools in README

## Testing
- `pytest -q` *(fails: Missing required packages torch)*

------
https://chatgpt.com/codex/tasks/task_e_684fdd18a7408331ac3d3802b3ec1461