### PR TITLE
Update Docker CMD to use tensorus.api package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,7 @@ ENV TENSORUS_AUTH_DEV_MODE_ALLOW_DUMMY_JWT="False"
 EXPOSE 7860
 
 # Define the command to run the application
-# This assumes your FastAPI app instance is named 'app' in 'tensorus.api.main'
-CMD ["uvicorn", "tensorus.api.main:app", "--host", "0.0.0.0", "--port", "7860"]
+# Use the package export from ``tensorus.api`` which exposes ``app`` in
+# ``tensorus/api/__init__.py``. This lets Uvicorn import the app directly
+# from the package without referencing the module path.
+CMD ["uvicorn", "tensorus.api:app", "--host", "0.0.0.0", "--port", "7860"]


### PR DESCRIPTION
## Summary
- point Uvicorn at `tensorus.api:app` so the Docker image uses the package export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff93b7dd48331b466a410691c0e54