### PR TITLE
Enforce tensor input shape validation

### DIFF
--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -358,13 +358,10 @@ def list_to_tensor(shape: List[int], dtype_str: str, data: Union[List[Any], int,
         if torch_dtype is None:
             raise ValueError(f"Unsupported dtype string: '{dtype_str}'. Supported: {list(dtype_map.keys())}")
 
-        # Optional: Perform strict validation before torch.tensor()
-        # This can catch structure errors early but might be redundant with torch.tensor checks.
-        # try:
-        #     _validate_tensor_data(data, shape)
-        # except ValueError as val_err:
-        #     logger.error(f"Input data validation failed for shape {shape}: {val_err}")
-        #     raise ValueError(f"Input data validation failed: {val_err}") from val_err
+        # Validate incoming list structure before constructing the tensor. This
+        # ensures mismatched shapes are caught early rather than relying on
+        # PyTorch's reshape logic.
+        _validate_tensor_data(data, shape)
 
         # Let torch handle initial conversion and type checking
         tensor = torch.tensor(data, dtype=torch_dtype)

--- a/tests/test_dataset_api.py
+++ b/tests/test_dataset_api.py
@@ -50,3 +50,20 @@ def test_records_pagination():
 
     r3 = client.get("/datasets/nonexistent/records")
     assert r3.status_code == 404
+
+
+def test_ingest_shape_mismatch():
+    ds = "mismatch_ds"
+    if not tensor_storage_instance.dataset_exists(ds):
+        client.post("/datasets/create", json={"name": ds})
+        TEST_DATASETS.add(ds)
+
+    # Provide flat data for a 2D shape to trigger validation error
+    payload = {
+        "shape": [2, 2],
+        "dtype": "float32",
+        "data": [1.0, 2.0, 3.0, 4.0],
+        "metadata": {"v": 1},
+    }
+    resp = client.post(f"/datasets/{ds}/ingest", json=payload)
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- validate tensor data inside `list_to_tensor`
- test ingestion failure for mismatched shapes

## Testing
- `pytest tests/test_dataset_api.py::test_ingest_shape_mismatch -q`
- `pytest tests/test_dataset_api.py::test_records_pagination -q`


------
https://chatgpt.com/codex/tasks/task_e_6850022af3b4833185082120832b3e09