### PR TITLE
Create query router module

### DIFF
--- a/tensorus/api/routers/query.py
+++ b/tensorus/api/routers/query.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import Any, Dict, List
+
+from ..utils import tensor_to_list
+from ...nql_agent import NQLAgent
+from ...tensor_storage import TensorStorage
+from ...api import NQLQueryRequest, NQLResponse, get_nql_agent
+
+router = APIRouter()
+
+@router.post("/query", response_model=NQLResponse)
+async def query_route(
+    request: NQLQueryRequest,
+    nql_agent: NQLAgent = Depends(get_nql_agent),
+):
+    """Execute an NQL query and convert tensors to list for JSON responses."""
+    try:
+        result = nql_agent.process_query(request.query)
+        if result.get("success") and isinstance(result.get("results"), list):
+            converted: List[Dict[str, Any]] = []
+            for rec in result["results"]:
+                shape, dtype, data = tensor_to_list(rec["tensor"])
+                converted.append(
+                    {
+                        "record_id": rec["metadata"].get("record_id"),
+                        "shape": shape,
+                        "dtype": dtype,
+                        "data": data,
+                        "metadata": rec["metadata"],
+                    }
+                )
+            result["results"] = converted
+        return NQLResponse(**result)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/tensorus/utils.py
+++ b/tensorus/utils.py
@@ -1,0 +1,13 @@
+from typing import Any, List, Tuple, Union
+
+import torch
+
+
+def tensor_to_list(tensor: torch.Tensor) -> Tuple[List[int], str, Union[List[Any], int, float]]:
+    """Convert a tensor to (shape, dtype, list data)."""
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError("Input must be a torch.Tensor")
+    shape = list(tensor.shape)
+    dtype_str = str(tensor.dtype).split(".")[-1]
+    data = tensor.tolist()
+    return shape, dtype_str, data


### PR DESCRIPTION
## Summary
- add missing query router that converts tensor outputs with `tensor_to_list`
- add utility module for tensor conversion

## Testing
- `pytest tests/test_api_query_llm.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6850065475808331adb9804692e8345c