### PR TITLE
Update uvicorn command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,12 @@ graph TD
 3.  Start the FastAPI backend server using:
 
     ```bash
-    python -m uvicorn tensorus.api:app --reload --host 127.0.0.1 --port 7860
+    uvicorn tensorus.api:app --host 0.0.0.0 --port 7860
     ```
 
-    *   The `python -m uvicorn` command ensures that Python runs Uvicorn as a module, and `tensorus.api:app` correctly points to the `app` instance within your `tensorus/api.py` file.
-    *   `--reload` enables auto-reload for development.
-    *   Access the API documentation at `http://127.0.0.1:7860/docs` or `http://127.0.0.1:7860/redoc`.
+    *   This command launches Uvicorn with the `app` instance defined in `tensorus/api.py`.
+    *   Access the API documentation at `http://localhost:7860/docs` or `http://localhost:7860/redoc`.
+    *   All dataset and agent endpoints are available once the server is running.
 
 ### Running the Streamlit UI
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,8 +47,10 @@ The easiest way to get Tensorus and its PostgreSQL backend running locally is by
 6.  Set up the necessary environment variables (see Configuration below).
 7.  Run the application using Uvicorn:
     ```bash
-    uvicorn tensorus.api.main:app --host 0.0.0.0 --port 7860 --reload # for development
+    uvicorn tensorus.api:app --host 0.0.0.0 --port 7860
     ```
+
+    This exposes all dataset and agent endpoints at `http://localhost:7860`.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- update README and installation docs to use `uvicorn tensorus.api:app --host 0.0.0.0 --port 7860`
- clarify that the server exposes dataset and agent endpoints

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68500b7663e08331a4953b205dc9a833