### PR TITLE
Add configurable security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,25 @@ The FastAPI documentation will then be available at `http://localhost:7860/docs`
 
 If your system has NVIDIA GPUs and the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) installed, you can pass `--gpus all` to `docker run` and modify `setup.sh` to install CUDA-enabled PyTorch wheels for GPU acceleration.
 
+### Deployment
+
+Tensorus adds several security headers by default. You can customize them with environment variables:
+
+* `TENSORUS_X_FRAME_OPTIONS` – value for the `X-Frame-Options` header (default `SAMEORIGIN`).
+* `TENSORUS_CONTENT_SECURITY_POLICY` – value for the `Content-Security-Policy` header (default `default-src 'self'`).
+
+If either variable is empty or set to `NONE`, the corresponding header is omitted.
+
+Example configuration:
+
+```bash
+# Allow embedding from a trusted site
+TENSORUS_X_FRAME_OPTIONS="ALLOW-FROM https://example.com"
+
+# Permit scripts from an external CDN
+TENSORUS_CONTENT_SECURITY_POLICY="default-src 'self'; script-src 'self' https://cdn.example.com"
+```
+
 ### Test Suite Dependencies
 
 The Python tests rely on packages from both `requirements.txt` and

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,31 @@
+import os
+from fastapi.testclient import TestClient
+from tensorus.api import app
+
+
+def test_security_headers_default(monkeypatch):
+    monkeypatch.delenv("TENSORUS_X_FRAME_OPTIONS", raising=False)
+    monkeypatch.delenv("TENSORUS_CONTENT_SECURITY_POLICY", raising=False)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.headers.get("X-Frame-Options") == "SAMEORIGIN"
+    assert resp.headers.get("Content-Security-Policy") == "default-src 'self'"
+
+
+def test_security_headers_custom(monkeypatch):
+    monkeypatch.setenv("TENSORUS_X_FRAME_OPTIONS", "ALLOW-FROM https://example.com")
+    policy = "default-src 'self'; script-src 'self' https://cdn.example.com"
+    monkeypatch.setenv("TENSORUS_CONTENT_SECURITY_POLICY", policy)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.headers["X-Frame-Options"] == "ALLOW-FROM https://example.com"
+    assert resp.headers["Content-Security-Policy"] == policy
+
+
+def test_security_headers_omitted(monkeypatch):
+    monkeypatch.setenv("TENSORUS_X_FRAME_OPTIONS", "NONE")
+    monkeypatch.setenv("TENSORUS_CONTENT_SECURITY_POLICY", "")
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert "X-Frame-Options" not in resp.headers
+    assert "Content-Security-Policy" not in resp.headers


### PR DESCRIPTION
## Summary
- make X-Frame-Options and CSP headers configurable via env vars
- document `TENSORUS_X_FRAME_OPTIONS` and `TENSORUS_CONTENT_SECURITY_POLICY`
- test header behavior with different env values

## Testing
- `./setup.sh`
- `pytest tests/test_security_headers.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850119e01188331954de092a31ace52