### PR TITLE
Update CSP docs for ReDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Tensorus adds several security headers by default. You can customize them with e
 * `TENSORUS_CONTENT_SECURITY_POLICY` – value for the `Content-Security-Policy` header (default `default-src 'self'`).
 
 If either variable is empty or set to `NONE`, the corresponding header is omitted.
+The default policy prevents ReDoc from loading its CDN assets. See [ReDoc and Content Security Policy](docs/api_guide.md#re-doc-and-content-security-policy) for an example policy that allows them.
 
 Example configuration:
 

--- a/docs/api_guide.md
+++ b/docs/api_guide.md
@@ -16,6 +16,18 @@ An alternative ReDoc interface is also available at:
 
 *   **`/redoc`**: [http://localhost:7860/redoc](http://localhost:7860/redoc)
 
+### ReDoc and Content Security Policy
+
+Tensorus sets the header `Content-Security-Policy: default-src 'self'` by default. This strict policy blocks the external fonts, stylesheets, and scripts that ReDoc loads from CDNs, so the ReDoc page will appear blank unless the policy is relaxed.
+
+To permit these assets you can override the policy via the `TENSORUS_CONTENT_SECURITY_POLICY` environment variable:
+
+```bash
+TENSORUS_CONTENT_SECURITY_POLICY="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://fastapi.tiangolo.com"
+```
+
+Set the variable to an empty string or `NONE` to remove the header entirely.
+
 ## Main API Categories
 
 The API is organized into several categories based on functionality:


### PR DESCRIPTION
## Summary
- document how default CSP blocks ReDoc
- add example policy string and describe disabling header
- note about CSP in README deployment instructions

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850171ea7d88331962e192fbc3c8561