### PR TITLE
Add extra filter parameters for listing tensor descriptors

### DIFF
--- a/tensorus/mcp_server.py
+++ b/tensorus/mcp_server.py
@@ -232,9 +232,10 @@ async def list_tensor_descriptors(
     rel_collection: Optional[str] = None,
     rel_has_related_tensor_id: Optional[str] = None,
     usage_last_accessed_before: Optional[str] = None,
-    usage_used_by_app: Optional[str] = None
-    # TODO: Add other simple query parameters like name, description, min_dimensions, etc.
-    # from tensorus/api/endpoints.py (ListTensorDescriptorsParams) if deemed necessary.
+    usage_used_by_app: Optional[str] = None,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    min_dimensions: Optional[int] = None
 ) -> TextContent:
     """List tensor descriptors with extensive optional filters."""
     params: Dict[str, Any] = {}
@@ -264,6 +265,12 @@ async def list_tensor_descriptors(
         params["usage.last_accessed_before"] = usage_last_accessed_before
     if usage_used_by_app is not None:
         params["usage.used_by_app"] = usage_used_by_app
+    if name is not None:
+        params["name"] = name
+    if description is not None:
+        params["description"] = description
+    if min_dimensions is not None:
+        params["min_dimensions"] = min_dimensions
 
     result = await _get("/tensor_descriptors/", params=params)
     return TextContent(type="text", text=json.dumps(result))

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -777,7 +777,10 @@ async def test_list_tensor_descriptors_with_params(monkeypatch):
         "relational.collection": "coll1",
         "relational.has_related_tensor_id": "uuid_str_123",
         "usage.last_accessed_before": "2023-01-01T00:00:00Z",
-        "usage.used_by_app": "app_x"
+        "usage.used_by_app": "app_x",
+        "name": "tensor_x",
+        "description": "some desc",
+        "min_dimensions": 3
     }
     make_mock_client(monkeypatch, "get", url, None, response, expected_params=params_to_send)
     result = await mcp_server.list_tensor_descriptors.fn(
@@ -793,8 +796,21 @@ async def test_list_tensor_descriptors_with_params(monkeypatch):
         rel_collection="coll1",
         rel_has_related_tensor_id="uuid_str_123",
         usage_last_accessed_before="2023-01-01T00:00:00Z",
-        usage_used_by_app="app_x"
+        usage_used_by_app="app_x",
+        name="tensor_x",
+        description="some desc",
+        min_dimensions=3
     )
+    assert isinstance(result, mcp_server.TextContent)
+    assert json.loads(result.text) == response
+
+@pytest.mark.asyncio
+async def test_list_tensor_descriptors_new_params(monkeypatch):
+    response = [{"id": "tensor999"}]
+    url = f"{mcp_server.API_BASE_URL}/tensor_descriptors/"
+    params = {"name": "t1", "description": "d1", "min_dimensions": 2}
+    make_mock_client(monkeypatch, "get", url, None, response, expected_params=params)
+    result = await mcp_server.list_tensor_descriptors.fn(name="t1", description="d1", min_dimensions=2)
     assert isinstance(result, mcp_server.TextContent)
     assert json.loads(result.text) == response
 


### PR DESCRIPTION
## Summary
- support `name`, `description` and `min_dimensions` in `list_tensor_descriptors`
- test additional parameters in MCP server tools

## Testing
- `pytest tests/test_mcp_server.py::test_list_tensor_descriptors_with_params -q` *(fails: ImportError: cannot import name 'field_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68503212c3c4833183e6c5317febeea8