### PR TITLE
Add prompt support and streamable HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Tensorus provides a lightweight Python implementation of the Model Context Proto
    ```bash
    python -m tensorus.mcp_server
    ```
-   Add `--transport sse` to use SSE transport.
+   Add `--transport streamable-http` for a web endpoint. SSE transport is deprecated.
    If you plan to run the MCP server tests in `tests/test_mcp_server.py` and `tests/test_mcp_client.py`, run `./setup.sh` beforehand to install all required packages.
 
 
@@ -633,7 +633,7 @@ You can also interact with the server using the included Python helper:
 from tensorus.mcp_client import TensorusMCPClient
 
 async def example_py():
-    async with TensorusMCPClient("http://localhost:7860/sse") as client:
+    async with TensorusMCPClient("http://localhost:7860/mcp") as client:
         tools = await client.list_datasets()
         print(tools)
 ```

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -909,3 +909,16 @@ async def test_delete_named_semantic_metadata_for_tensor(monkeypatch):
     result = await mcp_server.delete_named_semantic_metadata_for_tensor.fn(tensor_id=tensor_id, name=name)
     assert isinstance(result, mcp_server.TextContent)
     assert json.loads(result.text) == response
+
+
+@pytest.mark.asyncio
+async def test_prompt_functions(monkeypatch):
+    assert await mcp_server.ask_about_topic.fn("AI") == "Can you explain the concept of 'AI'?"
+    assert await mcp_server.summarize_text.fn(text="abc", max_length=5) == "Summarize the following in 5 words:\n\nabc"
+    assert await mcp_server.data_analysis_prompt.fn(data_uri="uri") == "Analyze the data at uri and report key insights."
+
+    dynamic_resp = {"info": 1}
+    url = f"{mcp_server.API_BASE_URL}/tensors/xyz/metadata"
+    make_mock_client(monkeypatch, "get", url, None, dynamic_resp)
+    result = await mcp_server.dynamic_prompt.fn(record_id="xyz")
+    assert "info" in result


### PR DESCRIPTION
## Summary
- switch to streamable-http transport and expose host/port/path options
- add several prompt helpers to mcp_server
- update README to reflect new transport
- test prompt helpers

## Testing
- `python -m py_compile tensorus/mcp_server.py tests/test_mcp_server.py`
- `pytest tests/test_mcp_server.py::test_save_tensor -q` *(fails: Missing required packages: torch)*

------
https://chatgpt.com/codex/tasks/task_e_68510d255fc88331b173dded78545322