### PR TITLE
Fix TextContent import fallback

### DIFF
--- a/tensorus/mcp_client.py
+++ b/tensorus/mcp_client.py
@@ -12,11 +12,9 @@ from fastmcp.exceptions import FastMCPError
 from fastmcp.transports.streamable_http import StreamableHTTPTransport
 
 # Minimal fallback for TextContent if import fails
-either
 try:
     from fastmcp.tools import TextContent
-nbecause
-except ImportError:
+except ImportError:  # pragma: no cover - support older fastmcp versions
     @dataclass
     class TextContent:
         type: str


### PR DESCRIPTION
## Summary
- remove stray words from `mcp_client.py`
- add ImportError comment and keep fallback dataclass

## Testing
- `python -m py_compile tensorus/mcp_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68511d812acc83319bff80b5d2b58a79