### PR TITLE
Add dev requirements and highlight setup script

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -17,7 +17,6 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt
-          python -m pip install -r requirements-test.txt
+          python -m pip install -r requirements-dev.txt
       - name: Run tests
         run: pytest -v

--- a/.github/workflows/models-tests.yml
+++ b/.github/workflows/models-tests.yml
@@ -24,8 +24,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          python -m pip install -r core/requirements.txt
-          python -m pip install -r core/requirements-test.txt
+          python -m pip install -r core/requirements-dev.txt
       - name: Prepare models package
         run: |
           mkdir -p models/tensorus

--- a/README.md
+++ b/README.md
@@ -314,7 +314,15 @@ before running `pytest` by executing the provided setup script:
 ./setup.sh
 ```
 
+Alternatively, install them directly using:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
 ### Running Tests
+
+**Important**: Run `./setup.sh` (or `pip install -r requirements-dev.txt`) before executing the tests. The suite exits early if required packages are missing.
 
 Tensorus includes Python unit tests. To set up the environment and run them:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# requirements-dev.txt
+# Combined dependencies for development and testing
+-r requirements.txt
+-r requirements-test.txt


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` combining runtime and test deps
- update README to emphasize running `setup.sh` before tests
- install dev requirements in CI workflows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `./setup.sh` *(partial output shown)*

------
https://chatgpt.com/codex/tasks/task_e_68511e8a531483319b054bb8a75db6e5