### PR TITLE
Update MCP client default URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ You can also interact with the server using the included Python helper:
 from tensorus.mcp_client import TensorusMCPClient
 
 async def example_py():
-    async with TensorusMCPClient("http://localhost:7860/mcp") as client:
+    async with TensorusMCPClient.from_http() as client:
         tools = await client.list_datasets()
         print(tools)
 ```

--- a/tensorus/mcp_client.py
+++ b/tensorus/mcp_client.py
@@ -20,6 +20,9 @@ T = TypeVar('T', bound=BaseModel)
 logger = logging.getLogger("tensorus.mcp.client")
 logger.setLevel(logging.INFO)
 
+# Default public MCP server hosted on HuggingFace Spaces
+DEFAULT_MCP_URL = "https://tensorus-mcp.hf.space/mcp/"
+
 class MCPResponseError(Exception):
     """Generic exception for MCP response errors"""
     pass
@@ -31,9 +34,14 @@ class TensorusMCPClient:
         self._client = FastMCPClient(transport)
 
     @staticmethod
-    def from_http(url: str) -> TensorusMCPClient:
-        """Factory using Streamable HTTP transport"""
-        transport = StreamableHttpTransport(url=url) # Updated class name usage
+    def from_http(url: str = DEFAULT_MCP_URL) -> TensorusMCPClient:
+        """Factory using Streamable HTTP transport.
+
+        Args:
+            url: Base URL of the MCP server. Defaults to the public
+                HuggingFace deployment.
+        """
+        transport = StreamableHttpTransport(url=url.rstrip("/"))
         return TensorusMCPClient(transport)
 
     async def __aenter__(self) -> TensorusMCPClient:

--- a/tensorus/mcp_server.py
+++ b/tensorus/mcp_server.py
@@ -85,13 +85,13 @@ async def fetch_metadata(record_id: str) -> dict:
 
 
 @server.prompt()
-def ask_about_topic(topic: str) -> str:
+async def ask_about_topic(topic: str) -> str:
     """Generate a user message asking for an explanation of a topic."""
     return f"Can you explain the concept of '{topic}'?"
 
 
 @server.prompt()
-def summarize_text(text: str = Field(description="Text to summarize"), max_length: int = 100) -> str:
+async def summarize_text(text: str = Field(description="Text to summarize"), max_length: int = 100) -> str:
     return f"Summarize the following in {max_length} words:\n\n{text}"
 
 
@@ -100,7 +100,7 @@ def summarize_text(text: str = Field(description="Text to summarize"), max_lengt
     description="Builds a prompt to analyze a dataset",
     tags={"analysis", "data"},
 )
-def data_analysis_prompt(data_uri: str) -> str:
+async def data_analysis_prompt(data_uri: str) -> str:
     return f"Analyze the data at {data_uri} and report key insights."
 
 


### PR DESCRIPTION
## Summary
- add `DEFAULT_MCP_URL` for HF deployment
- default `TensorusMCPClient.from_http()` to that URL
- adjust README example to use the new method
- make server prompt functions async to satisfy tests

## Testing
- `pytest tests/test_mcp_server.py::test_prompt_functions -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513f450d0083319e7dcfca98117af2