### PR TITLE
Update demo default for MCP URL

### DIFF
--- a/demo/mcp_client_app.py
+++ b/demo/mcp_client_app.py
@@ -3,12 +3,12 @@ import json
 
 import pandas as pd
 import streamlit as st
-from tensorus.mcp_client import TensorusMCPClient
+from tensorus.mcp_client import TensorusMCPClient, DEFAULT_MCP_URL
 
 st.title("Tensorus MCP Client Demo")
 st.markdown("Interact with a Tensorus MCP server without writing any code.")
 
-mcp_url = st.text_input("MCP server URL", TensorusMCPClient.DEFAULT_MCP_URL)
+mcp_url = st.text_input("MCP server URL", DEFAULT_MCP_URL)
 
 
 def run_async(coro):

--- a/tensorus/mcp_client.py
+++ b/tensorus/mcp_client.py
@@ -30,6 +30,9 @@ class MCPResponseError(Exception):
 class TensorusMCPClient:
     """High-level client for the Tensorus MCP server with typed, prompt, sync, and streaming support."""
 
+    # Retain class attribute for backward compatibility
+    DEFAULT_MCP_URL = DEFAULT_MCP_URL
+
     def __init__(self, transport: Any) -> None:
         self._client = FastMCPClient(transport)
 


### PR DESCRIPTION
## Summary
- import `DEFAULT_MCP_URL` in the Streamlit demo
- expose the constant as a class attribute for backwards compatibility

## Testing
- `pytest tests/test_mcp_client.py::test_create_dataset -q`
- `streamlit run demo/mcp_client_app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_6851581cc65083318f3aa083ab5f4fb1