### PR TITLE
Fix mcp_client_app import fallback

### DIFF
--- a/demo/mcp_client_app.py
+++ b/demo/mcp_client_app.py
@@ -3,7 +3,17 @@ import json
 
 import pandas as pd
 import streamlit as st
-from tensorus.mcp_client import TensorusMCPClient, DEFAULT_MCP_URL
+
+# Tensorus releases prior to 0.2.0 did not export DEFAULT_MCP_URL at the
+# module level. We attempt to import it, but gracefully fall back to the class
+# attribute or a hard-coded default so the demo works with older versions.
+try:
+    from tensorus.mcp_client import TensorusMCPClient, DEFAULT_MCP_URL
+except ImportError:  # pragma: no cover - fallback for old versions
+    from tensorus.mcp_client import TensorusMCPClient
+    DEFAULT_MCP_URL = getattr(
+        TensorusMCPClient, "DEFAULT_MCP_URL", "https://tensorus-mcp.hf.space/mcp/"
+    )
 
 st.title("Tensorus MCP Client Demo")
 st.markdown("Interact with a Tensorus MCP server without writing any code.")


### PR DESCRIPTION
## Summary
- handle missing `DEFAULT_MCP_URL` constant in `mcp_client_app`
- add fallback for older `tensorus` versions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68524baca1648331adca2897ba510baa