### PR TITLE
Fix MCP client demo

### DIFF
--- a/demo/mcp_client_demo.ipynb
+++ b/demo/mcp_client_demo.ipynb
@@ -15,7 +15,17 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "from tensorus.mcp_client import TensorusMCPClient"
+    "try:\n",
+    "    from tensorus.mcp_client import TensorusMCPClient, DEFAULT_MCP_URL\n",
+    "except ImportError:\n",
+    "    from tensorus.mcp_client import TensorusMCPClient\n",
+    "    DEFAULT_MCP_URL = getattr(TensorusMCPClient, 'DEFAULT_MCP_URL', 'https://tensorus-mcp.hf.space/mcp/')\n",
+    "\n",
+    "def client_from_http(url=DEFAULT_MCP_URL):\n",
+    "    if hasattr(TensorusMCPClient, 'from_http'):\n",
+    "        return TensorusMCPClient.from_http(url=url)\n",
+    "    from fastmcp.client.transports import StreamableHttpTransport\n",
+    "    return TensorusMCPClient(StreamableHttpTransport(url=url.rstrip('/')))\n"
    ]
   },
   {
@@ -27,7 +37,7 @@
     "import asyncio\n",
     "\n",
     "async def demo():\n",
-    "    async with TensorusMCPClient.from_http() as client:\n",
+    "    async with client_from_http() as client:\n",
     "        create_resp = await client.create_dataset(\"demo_ds\")\n",
     "        print(\"Create dataset:\", create_resp)\n",
     "\n",


### PR DESCRIPTION
## Summary
- avoid missing `from_http` errors by adding a compatibility helper
- update the notebook demo accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68524baca1648331adca2897ba510baa