### PR TITLE
Fix: Ensure trailing slash for MCP client URL

### DIFF
--- a/demo/mcp_client_app.py
+++ b/demo/mcp_client_app.py
@@ -91,3 +91,20 @@ if st.button("Execute") and query:
         st.write(pd.DataFrame(result.results))
     else:
         st.json(result.results)
+
+if __name__ == "__main__":
+    print("Attempting to list datasets automatically...")
+    async def _list_for_testing():
+        async with TensorusMCPClient.from_http(url=DEFAULT_MCP_URL) as client: # Use DEFAULT_MCP_URL
+            print("Client created, listing datasets...")
+            datasets = await client.list_datasets()
+            print(f"Successfully listed datasets: {datasets}")
+            return datasets
+
+    try:
+        asyncio.run(_list_for_testing())
+        print("Test: Successfully listed datasets without HTTPStatusError.")
+    except Exception as e:
+        print(f"Test: Encountered an error: {e}")
+        # Re-raise the exception to ensure the test fails if an error occurs
+        raise

--- a/tensorus/mcp_client.py
+++ b/tensorus/mcp_client.py
@@ -44,7 +44,8 @@ class TensorusMCPClient:
             url: Base URL of the MCP server. Defaults to the public
                 HuggingFace deployment.
         """
-        transport = StreamableHttpTransport(url=url.rstrip("/"))
+        final_url = url.rstrip("/") + "/"
+        transport = StreamableHttpTransport(url=final_url)
         return TensorusMCPClient(transport)
 
     async def __aenter__(self) -> TensorusMCPClient:


### PR DESCRIPTION
The fastmcp client, used by TensorusMCPClient, was encountering a 400 Bad Request error during disconnection when using the StreamableHttpTransport. This error appeared to be due to a POST request made during the disconnect sequence to the base MCP URL.

This commit modifies the `TensorusMCPClient.from_http` method to ensure that the URL provided to `StreamableHttpTransport` always ends with a trailing slash. This resolves the 400 error, suggesting the server expects a trailing slash for POST requests to its base endpoint, even during client disconnection.

I verified the fix by modifying and running the `demo/mcp_client_app.py` script to automatically perform the operation that previously triggered the error. The script completed successfully without the HTTPStatusError.