### PR TITLE
Add Gemini-based LLM parser to NQLAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,11 +423,11 @@ Chat" page in the Streamlit UI.
 
 ### Enabling LLM rewriting
 
-Set `NQL_USE_LLM=true` before starting the API server or Streamlit UI to enable
-experimental LLM rewriting of natural language queries. Optionally specify a
-model with `NQL_LLM_MODEL=<model-name>` (e.g., `google/flan-t5-base`). This
-feature relies on the heavy `transformers` dependency and may trigger a model
-download the first time it runs, which can take some time.
+Set `NQL_USE_LLM=true` to enable parsing of free‑form queries with
+Google's Gemini model. The agent sends the current dataset schema and
+your query to Gemini 2.0 Flash via `langchain-google`. Set
+`NQL_LLM_MODEL` (defaults to `gemini-2.0-flash`) to choose the model
+version. This may download model weights on first use.
 
 ## Agent Details
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,3 +16,5 @@ transformers
 psycopg2-binary
 python-jose[cryptography]
 fastmcp>=0.2.0
+langchain-google>=0.1.1
+langchain-google-genai>=2.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ torch>=1.13.0
 torchvision>=0.14.0
 segmentation-models-pytorch
 transformers
+langchain-google>=0.1.1
+langchain-google-genai>=2.1.5
 numpy>=1.21.0
 tensorly
 

--- a/tensorus/llm_parser.py
+++ b/tensorus/llm_parser.py
@@ -1,0 +1,58 @@
+import os
+import json
+import logging
+from typing import List, Any, Optional
+from pydantic import BaseModel, Field
+
+try:
+    from langchain_google_genai import ChatGoogleGenerativeAI
+    from langchain_core.prompts import ChatPromptTemplate
+    from langchain_core.output_parsers import PydanticOutputParser
+    from langchain_core.messages import SystemMessage, HumanMessage
+except Exception as e:  # pragma: no cover - library may be missing in test env
+    ChatGoogleGenerativeAI = None
+
+logger = logging.getLogger(__name__)
+
+class QueryCondition(BaseModel):
+    key: str
+    operator: str
+    value: Any
+
+class FilterClause(BaseModel):
+    joiner: str = Field("AND", description="Logical join for conditions")
+    conditions: List[QueryCondition] = Field(default_factory=list)
+
+class NQLQuery(BaseModel):
+    dataset: str
+    filters: List[FilterClause] = Field(default_factory=list)
+
+class LLMParser:
+    """Parse natural language queries into ``NQLQuery`` objects using Gemini."""
+
+    def __init__(self, model_name: Optional[str] = None):
+        model_name = model_name or os.getenv("NQL_LLM_MODEL", "gemini-2.0-flash")
+        if ChatGoogleGenerativeAI is None:
+            raise ImportError("langchain-google-genai is required for LLM parsing")
+        self.model = ChatGoogleGenerativeAI(model=model_name, temperature=0)
+        self.output_parser = PydanticOutputParser(pydantic_object=NQLQuery)
+        self.prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", "You convert user queries about datasets into JSON."
+                 " Use this format: {format_instructions}.\nDataset schema: {schema}"),
+                ("human", "{query}")
+            ]
+        )
+        self.chain = self.prompt | self.model | self.output_parser
+
+    def parse(self, query: str, schema: dict) -> Optional[NQLQuery]:
+        """Return ``NQLQuery`` parsed from ``query`` or ``None`` on failure."""
+        try:
+            return self.chain.invoke({
+                "query": query,
+                "schema": json.dumps(schema),
+                "format_instructions": self.output_parser.get_format_instructions(),
+            })
+        except Exception as e:  # pragma: no cover - runtime failures
+            logger.error(f"LLM parsing failed: {e}")
+            return None

--- a/tests/test_api_query_llm.py
+++ b/tests/test_api_query_llm.py
@@ -3,7 +3,6 @@ import importlib.util
 import pytest
 from unittest.mock import patch
 pytest.importorskip("torch")
-pytest.importorskip("transformers")
 import torch
 
 from fastapi.testclient import TestClient
@@ -16,12 +15,13 @@ api = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(api)
 from tensorus.nql_agent import NQLAgent
 from tensorus.tensor_storage import TensorStorage
+from tensorus.llm_parser import LLMParser, NQLQuery
 
 
 @pytest.fixture
 def client_with_llm(monkeypatch):
-    with patch("transformers.pipeline") as mock_root, patch("transformers.pipelines.pipeline") as mock_pipe:
-        mock_root.return_value = mock_pipe.return_value = lambda q: [{"generated_text": "get all data from test_ds"}]
+    with patch("tensorus.nql_agent.LLMParser") as MockParser:
+        MockParser.return_value.parse.return_value = NQLQuery(dataset="test_ds")
         storage = TensorStorage(storage_path=None)
         storage.create_dataset("test_ds")
         storage.insert("test_ds", torch.tensor([1.0]), metadata={"record_id": "r1"})

--- a/tests/test_nql_agent_llm.py
+++ b/tests/test_nql_agent_llm.py
@@ -1,11 +1,11 @@
 import pytest
 from unittest.mock import patch
 pytest.importorskip("torch")
-pytest.importorskip("transformers")
 import torch
 
 from tensorus.nql_agent import NQLAgent
 from tensorus.tensor_storage import TensorStorage
+from tensorus.llm_parser import LLMParser, NQLQuery
 
 @pytest.fixture
 def sample_storage():
@@ -15,22 +15,20 @@ def sample_storage():
     return storage
 
 
-def test_process_query_uses_llm_rewrite(sample_storage):
-    with patch("transformers.pipeline") as mock_root, patch("transformers.pipelines.pipeline") as mock_pipe:
-        mock_root.return_value = mock_pipe.return_value = lambda q: [{"generated_text": "get all data from test_ds"}]
+def test_process_query_uses_llm(sample_storage):
+    with patch("tensorus.nql_agent.LLMParser") as MockParser:
+        MockParser.return_value.parse.return_value = NQLQuery(dataset="test_ds")
         agent = NQLAgent(sample_storage, use_llm=True)
-        with patch.object(agent, "_llm_rewrite_query", wraps=agent._llm_rewrite_query) as spy:
-            result = agent.process_query("unknown text")
-            assert spy.call_count == 1
-            assert result["success"]
-            assert result["count"] == 1
+        result = agent.process_query("unknown text")
+        MockParser.return_value.parse.assert_called_once()
+        assert result["success"]
+        assert result["count"] == 1
 
 
-def test_rewrite_stops_after_failure(sample_storage):
-    with patch("transformers.pipeline") as mock_root, patch("transformers.pipelines.pipeline") as mock_pipe:
-        mock_root.return_value = mock_pipe.return_value = lambda q: [{"generated_text": "still unsupported"}]
+def test_parse_failure_returns_error(sample_storage):
+    with patch("tensorus.nql_agent.LLMParser") as MockParser:
+        MockParser.return_value.parse.return_value = None
         agent = NQLAgent(sample_storage, use_llm=True)
-        with patch.object(agent, "_llm_rewrite_query", wraps=agent._llm_rewrite_query) as spy:
-            result = agent.process_query("bad query")
-            assert spy.call_count == 1
-            assert not result["success"]
+        result = agent.process_query("bad query")
+        MockParser.return_value.parse.assert_called_once()
+        assert not result["success"]


### PR DESCRIPTION
## Summary
- add `LLMParser` powered by langchain-google Gemini models
- update NQLAgent to use LLMParser when `NQL_USE_LLM` is set
- expose env var `NQL_LLM_MODEL`
- document Gemini support and environment variables
- update tests for new LLM integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bbbd31e48331a9a8f14bd082b7af