### PR TITLE
Improve docs for Gemini NQL parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,10 +424,21 @@ Chat" page in the Streamlit UI.
 ### Enabling LLM rewriting
 
 Set `NQL_USE_LLM=true` to enable parsing of free‑form queries with
-Google's Gemini model. The agent sends the current dataset schema and
-your query to Gemini 2.0 Flash via `langchain-google`. Set
-`NQL_LLM_MODEL` (defaults to `gemini-2.0-flash`) to choose the model
-version. This may download model weights on first use.
+Google's Gemini model. Provide your API key in the `GOOGLE_API_KEY`
+environment variable and optionally set `NQL_LLM_MODEL` (defaults to
+`gemini-2.0-flash`) to choose the model version. The agent sends the
+current dataset schema and your query to Gemini via
+`langchain-google`. If the model or key are unavailable the agent
+silently falls back to the regex-based parser.
+
+Example query using the LLM parser:
+
+```text
+show me all images containing a dog from dataset animals where source is "mobile"
+```
+
+This phrasing is more natural than the regex format and will be
+rewritten into a structured NQL query by Gemini.
 
 ## Agent Details
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,6 +69,12 @@ Tensorus is configured via environment variables. Key variables include:
 *   `TENSORUS_API_KEY_HEADER_NAME`: HTTP header name for the API key (default: `X-API-KEY`).
 *   `TENSORUS_MINIMAL_IMPORT`: Set to any value to skip importing the optional
     `tensorus-models` package for a lightweight installation.
+*   `NQL_USE_LLM`: Set to `true` to enable the Gemini-based natural query
+    parser. Requires `GOOGLE_API_KEY`.
+*   `NQL_LLM_MODEL`: (Optional) Gemini model name (default
+    `gemini-2.0-flash`).
+*   `GOOGLE_API_KEY`: Your key for Google AI Studio. If not provided or the
+    model fails to load, Tensorus falls back to regex parsing.
 
 ### JWT Authentication (Conceptual - For Future Use)
 *   `TENSORUS_AUTH_JWT_ENABLED`: `True` or `False` (default `False`).


### PR DESCRIPTION
## Summary
- document how to enable the Gemini-based NQL parser
- explain necessary environment variables in installation docs
- show example query and note regex fallback

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d4aacf3083319743306908f10b22