### PR TITLE
Document MCP session handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ The Tensorus Model Context Protocol (MCP) Server allows external AI agents, LLM-
 *   **Language:** Python, using the `fastmcp` library.
 *   **Communication:** Typically uses stdio for communication with a single client.
 *   **Interface:** Exposes Tensorus capabilities as a set of "tools" that an MCP client can list and call.
+*   **Session Handshake:** Clients must first request `/mcp/` with `GET` or `HEAD` to receive an `mcp-session-id` header. Include this value in subsequent calls. See [Session Handshake](docs/mcp_client.md#session-handshake) for an example.
 
 ### Available Tools
 

--- a/docs/mcp_client.md
+++ b/docs/mcp_client.md
@@ -18,6 +18,28 @@ Below is a summary of all available methods.  See the
 [API Guide](api_guide.md) and [API Endpoints](../README.md#api-endpoints) in the
 README for details on the REST endpoints each method calls.
 
+## Session Handshake
+
+Before making any tool calls, a client must obtain a session identifier from the
+MCP server. Issue an initial `GET` or `HEAD` request to `/mcp/` and capture the
+value of the `mcp-session-id` response header. This ID must then be included in
+the `mcp-session-id` header on all subsequent MCP requests.
+
+Example using `curl`:
+
+```bash
+# Fetch the session ID
+SESSION_ID=$(curl -i https://your-server.example/mcp/ \
+  | grep -Fi "mcp-session-id" | awk '{print $2}' | tr -d '\r')
+
+# Call a tool using the session header
+curl -X POST https://your-server.example/mcp/ \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"method":"tools/list"}'
+```
+
 ## Dataset Management
 
 - `list_datasets()` – list existing datasets.


### PR DESCRIPTION
## Summary
- add instructions about the MCP session handshake
- show a `curl` example for obtaining the session ID and calling tools
- link the handshake section from the README

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685404645c0c83318c29d7072cb16c85