### PR TITLE
fix: Integrate API key support in MCP client and update tests

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -4,6 +4,7 @@ import pytest
 from tensorus import mcp_client
 from tensorus.mcp_client import TensorusMCPClient, TextContent
 
+TEST_API_KEY = "client_test_key_456"
 
 class DummyFastClient:
     def __init__(self):
@@ -46,9 +47,9 @@ class DummyFastClient:
 async def test_create_dataset(monkeypatch):
     dummy = DummyFastClient()
     monkeypatch.setattr(mcp_client, "FastMCPClient", lambda transport: dummy)
-    async with TensorusMCPClient("dummy") as client:
+    async with TensorusMCPClient("dummy", api_key=TEST_API_KEY) as client:
         result = await client.create_dataset("ds1")
-    assert dummy.calls == [("tensorus_create_dataset", {"dataset_name": "ds1"})]
+    assert dummy.calls == [("tensorus_create_dataset", {"dataset_name": "ds1", "api_key": TEST_API_KEY})]
     assert result.success is True
     assert result.message == "Dataset ds1 created"
 
@@ -57,9 +58,18 @@ async def test_create_dataset(monkeypatch):
 async def test_ingest_tensor(monkeypatch):
     dummy = DummyFastClient()
     monkeypatch.setattr(mcp_client, "FastMCPClient", lambda transport: dummy)
-    async with TensorusMCPClient("dummy") as client:
+    async with TensorusMCPClient("dummy", api_key=TEST_API_KEY) as client:
         res = await client.ingest_tensor("ds", [1, 2], "float32", [1, 2], {"x": 1})
-    assert dummy.calls[0][0] == "tensorus_ingest_tensor"
+
+    expected_args = {
+        "dataset_name": "ds",
+        "tensor_shape": [1, 2],
+        "tensor_dtype": "float32",
+        "tensor_data": [1, 2],
+        "metadata": {"x": 1},
+        "api_key": TEST_API_KEY
+    }
+    assert dummy.calls == [("tensorus_ingest_tensor", expected_args)]
     assert res.id == "tensor_id_123"
     assert res.status == "ingested"
 
@@ -68,37 +78,49 @@ async def test_ingest_tensor(monkeypatch):
 async def test_execute_nql_query(monkeypatch):
     dummy = DummyFastClient()
     monkeypatch.setattr(mcp_client, "FastMCPClient", lambda transport: dummy)
-    async with TensorusMCPClient("dummy") as client:
+    async with TensorusMCPClient("dummy", api_key=TEST_API_KEY) as client:
         res = await client.execute_nql_query("count")
-    assert dummy.calls == [("execute_nql_query", {"query": "count"})]
+    assert dummy.calls == [("execute_nql_query", {"query": "count", "api_key": TEST_API_KEY})]
     assert res.results == ["result1", "result2"]
+
+
+@pytest.mark.asyncio
+async def test_create_dataset_no_api_key(monkeypatch):
+    dummy = DummyFastClient()
+    monkeypatch.setattr(mcp_client, "FastMCPClient", lambda transport: dummy)
+    # Instantiate client without API key
+    async with TensorusMCPClient("dummy") as client:
+        result = await client.create_dataset("ds2")
+    # Assert that api_key is NOT in the arguments
+    assert dummy.calls == [("tensorus_create_dataset", {"dataset_name": "ds2"})]
+    assert result.success is True
 
 
 @pytest.mark.asyncio
 async def test_additional_methods(monkeypatch):
     dummy = DummyFastClient()
     monkeypatch.setattr(mcp_client, "FastMCPClient", lambda transport: dummy)
-    async with TensorusMCPClient("dummy") as client:
+    async with TensorusMCPClient("dummy", api_key=TEST_API_KEY) as client:
         td = await client.create_tensor_descriptor({"name": "desc"})
         lm = await client.get_lineage_metadata("tid")
         search = await client.search_tensors("q")
         version = await client.create_tensor_version("tid", {"tag": "v1"})
-        export = await client.export_tensor_metadata()
-        analytics = await client.analytics_get_complex_tensors()
+        export = await client.export_tensor_metadata() # No specific args other than api_key
+        analytics = await client.analytics_get_complex_tensors() # Default args + api_key
 
     assert td.id == "td1"
     assert lm.tensor_descriptor_id == "tid"
-    assert search == [{"id": "t1"}]
+    assert search == [{"id": "t1"}] # Assuming search_tensors returns list directly
     assert version["version_id"] == "v1"
-    assert export == [{"id": "t1"}]
-    assert analytics == [{"tensor_id": "t2"}]
+    assert export == [{"id": "t1"}] # Assuming export_tensor_metadata returns list
+    assert analytics == [{"tensor_id": "t2"}] # Assuming analytics_get_complex_tensors returns list
 
-    called = [c[0] for c in dummy.calls]
-    assert called == [
-        "create_tensor_descriptor",
-        "get_lineage_metadata",
-        "search_tensors",
-        "create_tensor_version",
-        "export_tensor_metadata",
-        "analytics_get_complex_tensors",
+    expected_calls = [
+        ("create_tensor_descriptor", {"descriptor_data": {"name": "desc"}, "api_key": TEST_API_KEY}),
+        ("get_lineage_metadata", {"tensor_id": "tid", "api_key": TEST_API_KEY}),
+        ("search_tensors", {"text_query": "q", "api_key": TEST_API_KEY}),
+        ("create_tensor_version", {"tensor_id": "tid", "version_request": {"tag": "v1"}, "api_key": TEST_API_KEY}),
+        ("export_tensor_metadata", {"api_key": TEST_API_KEY}),
+        ("analytics_get_complex_tensors", {"limit": 100, "api_key": TEST_API_KEY}), # limit is default
     ]
+    assert dummy.calls == expected_calls

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1920,6 +1920,38 @@ async def test_delete_named_semantic_metadata_for_tensor_with_api_key(monkeypatc
     assert isinstance(result, mcp_server.TextContent)
     assert json.loads(result.text) == response
 
+@pytest.mark.asyncio
+async def test_delete_named_semantic_metadata_for_tensor_with_global_key(monkeypatch):
+    global_key = "delete_named_sem_global"
+    original_global_key = mcp_server.GLOBAL_API_KEY
+    mcp_server.GLOBAL_API_KEY = global_key
+    try:
+        tensor_id = "tensor123"
+        name = "sem_meta_1_global"
+        response = {"message": f"Semantic metadata '{name}' for tensor descriptor '{tensor_id}' deleted successfully."}
+        url = f"{mcp_server.API_BASE_URL}/tensor_descriptors/{tensor_id}/semantic/{name}"
+        make_mock_client(monkeypatch, "delete", url, None, response, expected_headers={settings.API_KEY_HEADER_NAME: global_key})
+        result = await mcp_server.delete_named_semantic_metadata_for_tensor.fn(tensor_id=tensor_id, name=name)
+        assert isinstance(result, mcp_server.TextContent)
+        assert json.loads(result.text) == response
+    finally:
+        mcp_server.GLOBAL_API_KEY = original_global_key
+
+@pytest.mark.asyncio
+async def test_delete_named_semantic_metadata_for_tensor_no_key(monkeypatch):
+    original_global_key = mcp_server.GLOBAL_API_KEY
+    mcp_server.GLOBAL_API_KEY = None
+    try:
+        tensor_id = "tensor123"
+        name = "sem_meta_1_no_key"
+        response = {"message": f"Semantic metadata '{name}' for tensor descriptor '{tensor_id}' deleted successfully."}
+        url = f"{mcp_server.API_BASE_URL}/tensor_descriptors/{tensor_id}/semantic/{name}"
+        make_mock_client(monkeypatch, "delete", url, None, response, expected_headers={})
+        result = await mcp_server.delete_named_semantic_metadata_for_tensor.fn(tensor_id=tensor_id, name=name)
+        assert isinstance(result, mcp_server.TextContent)
+        assert json.loads(result.text) == response
+    finally:
+        mcp_server.GLOBAL_API_KEY = original_global_key
 
 @pytest.mark.asyncio
 async def test_prompt_functions(monkeypatch):


### PR DESCRIPTION
This commit addresses your feedback regarding console 404 errors and MCP client logic.

1.  **404 Error Investigation**:
    *   Analysis of `tensorus/mcp_server.py` confirmed that the 404 errors for paths like `/`, `/register`, and `/.well-known/*` are expected. The MCP server is specialized for tool proxying under its configured path (`/mcp`) and does not define these general web application routes. No server-side misconfiguration was identified for these 404s.

2.  **MCP Client API Key Integration (`tensorus/mcp_client.py`)**:
    *   `TensorusMCPClient` constructor and `from_http` factory method now accept an optional `api_key` parameter.
    *   If an API key is provided at instantiation, it is stored in the client instance.
    *   The internal `_call_json` method automatically includes this stored API key in the arguments dictionary (under the key `"api_key"`) passed to the underlying `FastMCPClient.call_tool` method. This ensures the API key is sent to the MCP server tools that now expect it.

3.  **Integration Test Updates (`tests/test_mcp_integration.py`)**:
    *   The `mcp_servers` fixture was updated to:
        *   Configure the backend API server (`tensorus.api:app`) with a `TENSORUS_VALID_API_KEYS` environment variable set to a defined `TEST_API_KEY`.
        *   Start the `tensorus/mcp_server.py` with the `--mcp-api-key` argument set to the same `TEST_API_KEY` (for its global fallback).
    *   All integration tests now instantiate `TensorusMCPClient` using `from_http` with the `api_key=TEST_API_KEY` argument, ensuring tests run in an authenticated context.

4.  **Client Unit Test Updates (`tests/test_mcp_client.py`)**:
    *   Tests were updated to instantiate `TensorusMCPClient` with a `TEST_API_KEY`.
    *   Assertions on the arguments received by the mocked `FastMCPClient.call_tool` were updated to verify that the `"api_key"` is correctly included.
    *   A new test was added to ensure the `api_key` is *not* included in the arguments if the client is instantiated without one.

These changes ensure that the MCP client can properly pass API keys to the MCP server, and that the integration and client unit tests are aligned with this new authentication flow.