### PR TITLE
Add optional token for MCP client HTTP auth

### DIFF
--- a/tensorus/mcp_client.py
+++ b/tensorus/mcp_client.py
@@ -62,15 +62,18 @@ class TensorusMCPClient:
         self._client = FastMCPClient(transport)
 
     @staticmethod
-    def from_http(url: str = DEFAULT_MCP_URL) -> TensorusMCPClient:
+    def from_http(url: str = DEFAULT_MCP_URL, token: Optional[str] = None) -> TensorusMCPClient:
         """Factory using Streamable HTTP transport.
 
         Args:
             url: Base URL of the MCP server. Defaults to the public
                 HuggingFace deployment.
+            token: Optional bearer token for accessing a private HuggingFace
+                Space or other authenticated deployment.
         """
         final_url = url.rstrip("/") + "/"
-        transport = StreamableHttpTransport(url=final_url)
+        headers = {"Authorization": f"Bearer {token}"} if token else None
+        transport = StreamableHttpTransport(url=final_url, headers=headers)
         return TensorusMCPClient(transport)
 
     async def __aenter__(self) -> TensorusMCPClient:


### PR DESCRIPTION
## Summary
- allow `TensorusMCPClient.from_http` to accept a token and pass an Authorization header
- test that headers are forwarded when token supplied

## Testing
- `pytest tests/test_mcp_client.py::test_from_http_with_token tests/test_mcp_client.py::test_from_http_without_token -q`

------
https://chatgpt.com/codex/tasks/task_e_685427ec995c833188741830753e90d9