### PR TITLE
Add connection test and backend ping tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,14 @@ These tools help you check the status of the MCP server and its connection to th
     *   Description: Checks the MCP server's current operational status, mode (live or demo), and API key configuration.
     *   Usage: Call this tool to get a JSON response with server status details.
 
+*   **`connection_test()`**:
+    *   Description: Lightweight connectivity check that simply returns `{"status": "ok"}`.
+    *   Usage: Call this tool to confirm the MCP server is reachable.
+
+*   **`backend_ping()`**:
+    *   Description: Calls the backend API's `/health` endpoint and returns the result (or demo data when in demo mode).
+    *   Usage: Use this when you want the raw response from the backend health check.
+
 *   **`backend_connectivity_test()`**:
     *   Description: Tests connectivity to the backend API's `/health` endpoint. In demo mode, it returns a mock success response. In live mode, it attempts a real connection and reports the outcome.
     *   Usage: Call this tool to verify if the server can communicate with the backend.

--- a/tensorus/mcp_server.py
+++ b/tensorus/mcp_server.py
@@ -750,6 +750,23 @@ async def mcp_server_status() -> TextContent:
 
 
 @server.tool()
+async def connection_test() -> TextContent:
+    """Simple connectivity test returning a static ok status."""
+    return TextContent(type="text", text=json.dumps({"status": "ok"}))
+
+
+@server.tool()
+async def backend_ping() -> TextContent:
+    """Ping the backend `/health` endpoint and forward the response."""
+    if DEMO_MODE:
+        return TextContent(
+            type="text", text=json.dumps(DEMO_RESPONSES.get("/health", {"status": "healthy", "demo_mode": True}))
+        )
+    result = await _get("/health")
+    return TextContent(type="text", text=json.dumps(result))
+
+
+@server.tool()
 async def backend_connectivity_test() -> TextContent:
     """Test connectivity to the backend API.
     In demo mode, this will return a mock success response.


### PR DESCRIPTION
## Summary
- add `connection_test` tool for quick status check
- add `backend_ping` tool that proxies backend `/health`
- document the new tools in README

## Testing
- `pytest -k mcp_server -q` *(fails: Missing required packages)*

------
https://chatgpt.com/codex/tasks/task_e_6855167f156083318098bcd2371f8a6f