### PR TITLE
Centralize logging config

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,8 +28,7 @@ st.set_page_config(
     initial_sidebar_state="collapsed" # Collapse sidebar as nav is now at top
 )
 
-# --- Configure Logging (Optional but good practice) ---
-logging.basicConfig(level=logging.INFO)
+# --- Configure Logging ---
 logger = logging.getLogger(__name__)
 
 # --- Integrated Tensor Utilities (Preserved) ---

--- a/tensorus/__init__.py
+++ b/tensorus/__init__.py
@@ -1,6 +1,18 @@
 """Tensorus core package."""
 
 import os
+import logging
+
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Initialize root logger if not already configured."""
+    if not logging.getLogger().handlers:
+        logging.basicConfig(level=level, format=LOG_FORMAT, handlers=[logging.StreamHandler()])
+
+
+configure_logging()
 
 # The repository previously exposed a large collection of models under
 # ``tensorus.models``. These models have been moved to a separate package.

--- a/tensorus/api.py
+++ b/tensorus/api.py
@@ -32,12 +32,6 @@ from tensorus.api.endpoints import (
 )
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
-# Configure structured logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler()]
-)
 logger = logging.getLogger(__name__)
 
 # Custom exceptions

--- a/tensorus/audit.py
+++ b/tensorus/audit.py
@@ -3,27 +3,20 @@ from typing import Optional, Dict, Any
 import sys
 from tensorus.config import settings
 
-# Configure basic logger
-# In a real app, this might be more complex (e.g., JSON logging, log rotation, external service)
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-LOG_DEFAULT_HANDLERS = [logging.StreamHandler(sys.stdout)] # Log to stdout by default
 
-# Attempt to create a log file handler.
-# This is a simple file logger; in production, consider more robust solutions.
+audit_logger = logging.getLogger("tensorus.audit")
+audit_logger.setLevel(logging.INFO)
+
 try:
     file_handler = logging.FileHandler(settings.AUDIT_LOG_PATH)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
-    LOG_DEFAULT_HANDLERS.append(file_handler)
+    audit_logger.addHandler(file_handler)
 except IOError:
-    # Handle cases where file cannot be opened (e.g. permissions)
     print(
         f"Warning: Could not open {settings.AUDIT_LOG_PATH} for writing. Audit logs will go to stdout only.",
         file=sys.stderr,
     )
-
-
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, handlers=LOG_DEFAULT_HANDLERS)
-audit_logger = logging.getLogger("tensorus.audit")
 
 
 def log_audit_event(

--- a/tensorus/automl_agent.py
+++ b/tensorus/automl_agent.py
@@ -27,8 +27,6 @@ from typing import Dict, Any, Callable, Tuple, Optional
 
 from .tensor_storage import TensorStorage # Import our storage module
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 

--- a/tensorus/ingestion_agent.py
+++ b/tensorus/ingestion_agent.py
@@ -31,8 +31,6 @@ import collections # Added import
 from typing import Dict, Callable, Optional, Tuple, List, Any
 from .tensor_storage import TensorStorage # Import our storage module
 
-# Configure basic logging (can be customized further)
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 

--- a/tensorus/metadata/postgres_storage.py
+++ b/tensorus/metadata/postgres_storage.py
@@ -14,9 +14,6 @@ from .schemas import (
 )
 import copy # Ensure copy is imported, as it was added to InMemoryStorage and might be useful here too.
 
-# Configure module level logging
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 __all__ = ["PostgresMetadataStorage"]

--- a/tensorus/metadata/storage.py
+++ b/tensorus/metadata/storage.py
@@ -12,9 +12,6 @@ from .storage_abc import MetadataStorage
 from .schemas_iodata import TensorusExportData, TensorusExportEntry
 import copy
 
-# Configure module level logging
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 # In-memory storage using dictionaries

--- a/tensorus/nql_agent.py
+++ b/tensorus/nql_agent.py
@@ -32,8 +32,6 @@ from .llm_parser import LLMParser, NQLQuery, FilterClause, QueryCondition
 
 from .tensor_storage import TensorStorage, DatasetNotFoundError
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 class NQLAgent:

--- a/tensorus/rl_agent.py
+++ b/tensorus/rl_agent.py
@@ -26,8 +26,6 @@ from typing import Tuple, Optional, Dict, Any
 from .tensor_storage import TensorStorage
 from .dummy_env import DummyEnv # Import our dummy environment
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 

--- a/tensorus/tensor_ops.py
+++ b/tensorus/tensor_ops.py
@@ -22,9 +22,6 @@ import tensorly as tl
 # CPTensor is a namedtuple, can be used for type hinting if specific
 # from tensorly.cp_tensor import CPTensor
 
-# Configure basic logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 class TensorOps:
     """
     A static library class providing robust tensor operations.

--- a/tensorus/tensor_storage.py
+++ b/tensorus/tensor_storage.py
@@ -28,9 +28,6 @@ _TYPE_MAP = {
     "dict": dict,
 }
 
-# Configure basic logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 class TensorStorage:
     """
     Manages datasets stored as collections of tensors in memory.

--- a/tensorus/time_series_predictor.py
+++ b/tensorus/time_series_predictor.py
@@ -8,9 +8,6 @@ from typing import List, Dict, Any, Optional, Tuple
 import logging
 import time # For timestamp in metadata if needed
 
-# Configure basic logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - [%(filename)s:%(lineno)d] - %(message)s')
-
 def load_time_series_from_tensorus(
     storage: TensorStorage,
     dataset_name: str,


### PR DESCRIPTION
## Summary
- add `configure_logging` in `tensorus/__init__`
- remove multiple `logging.basicConfig` calls across modules

## Testing
- `./setup.sh`
- `pytest -q` *(fails: 37 failed, 439 passed, 9 skipped, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685802e1d40c83318d773a69ab60b296