### PR TITLE
Fix script execution imports

### DIFF
--- a/tensorus/audit.py
+++ b/tensorus/audit.py
@@ -1,3 +1,8 @@
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
+
 import logging
 from typing import Optional, Dict, Any
 import sys

--- a/tensorus/automl_agent.py
+++ b/tensorus/automl_agent.py
@@ -16,6 +16,11 @@ Future Enhancements:
 - Use dedicated hyperparameter optimization libraries (Optuna, Ray Tune).
 """
 
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
+
 import torch
 import torch.nn as nn
 import torch.optim as optim

--- a/tensorus/dummy_env.py
+++ b/tensorus/dummy_env.py
@@ -6,6 +6,11 @@ Action: Move left (-1), Stay (0), Move right (+1) (Discrete actions)
 Goal: Reach position 0
 Reward: -abs(position), +10 if at goal
 """
+
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
 from typing import Tuple, Dict
 import torch
 import random

--- a/tensorus/financial_data_generator.py
+++ b/tensorus/financial_data_generator.py
@@ -1,3 +1,8 @@
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
+
 import pandas as pd
 import numpy as np
 import datetime

--- a/tensorus/ingestion_agent.py
+++ b/tensorus/ingestion_agent.py
@@ -17,6 +17,11 @@ Future Enhancements:
 - Resource management controls.
 """
 
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
+
 import os
 import time
 import glob

--- a/tensorus/mcp_server.py
+++ b/tensorus/mcp_server.py
@@ -5,6 +5,11 @@ backend.  Tools mirror the ones documented in the README under "Available
 Tools" and return results as :class:`TextContent` objects.
 """
 
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
+
 import argparse
 import json
 from typing import Any, Optional, Sequence, Dict

--- a/tensorus/nql_agent.py
+++ b/tensorus/nql_agent.py
@@ -21,6 +21,11 @@ Future Enhancements:
 - Context awareness and conversation history.
 """
 
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
+
 import re
 import logging
 import math

--- a/tensorus/rl_agent.py
+++ b/tensorus/rl_agent.py
@@ -12,6 +12,11 @@ Note on Experience Storage:
 - This approach balances tensor-native storage with manageable metadata, but sampling
   requires retrieving linked state tensors, which might be slow depending on storage backend.
 """
+
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
 from typing import Any
 import torch
 import torch.nn as nn

--- a/tensorus/tensor_decompositions.py
+++ b/tensorus/tensor_decompositions.py
@@ -5,6 +5,11 @@ This module will contain various tensor decomposition algorithms
 like CP, Tucker, TT, TR, etc.
 """
 
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
+
 import torch
 import tensorly as tl
 from typing import List, Tuple, Union, Optional, Dict

--- a/tensorus/tensor_storage.py
+++ b/tensorus/tensor_storage.py
@@ -1,3 +1,7 @@
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
 
 import torch
 from typing import List, Dict, Callable, Optional, Any

--- a/tensorus/time_series_predictor.py
+++ b/tensorus/time_series_predictor.py
@@ -1,3 +1,8 @@
+if __package__ in (None, ""):
+    import os, sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = "tensorus"
+
 import torch
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
## Summary
- support running audit script directly
- support running ingest, automl, nql, rl, tensor ops, and other utilities directly

## Testing
- `./setup.sh` *(fails: Attempting uninstall etc.)*
- `pytest -q` *(fails to import fastmcp and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_6858242e2c708331b9068ff0c7154d75