### PR TITLE
Fix duplicate import in mcp_server

### DIFF
--- a/tensorus/mcp_server.py
+++ b/tensorus/mcp_server.py
@@ -21,7 +21,6 @@ from tensorus.config import settings
 import httpx
 from httpx import HTTPStatusError
 from fastmcp import FastMCP
-from httpx import HTTPStatusError  # Ensure this is kept from previous change
 
 try:
     from fastmcp.prompts.prompt import PromptMessage, Message, TextContent


### PR DESCRIPTION
## Summary
- remove the duplicated `HTTPStatusError` import

## Testing
- `python -m py_compile tensorus/mcp_server.py`
- `pytest -k mcp_server -q` *(fails: Missing required packages)*

------
https://chatgpt.com/codex/tasks/task_e_6858269abe208331802ffcf64a1b690f