### PR TITLE
Add list_tools support

### DIFF
--- a/docs/mcp_client.md
+++ b/docs/mcp_client.md
@@ -18,6 +18,14 @@ Below is a summary of all available methods.  See the
 [API Guide](api_guide.md) and [API Endpoints](../README.md#api-endpoints) in the
 README for details on the REST endpoints each method calls.
 
+## Server Introspection
+
+- `list_tools()` – retrieve the list of tool names available from the MCP
+  server.
+  ```python
+  tool_names = await client.list_tools()
+  ```
+
 ## Dataset Management
 
 - `list_datasets()` – list existing datasets.


### PR DESCRIPTION
## Summary
- expose list_tools in TensorusMCPClient
- document the new method
- test listing tools with DummyFastClient

## Testing
- `pytest -q` *(fails: Missing required packages: torch)*

------
https://chatgpt.com/codex/tasks/task_e_685d5b067c048331b2cb11f2d0b870f3