### PR TITLE
Update MCP server install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,12 @@ Tensorus provides a lightweight Python implementation of the Model Context Proto
 
 **Starting the MCP Server:**
 
-1. Install dependencies (includes `fastmcp`):
+1. Install dependencies. The MCP server requires the `fastmcp` package:
    ```bash
+   pip install fastmcp
    pip install -r requirements.txt
    ```
+   Running `./setup.sh` will install `fastmcp` and all other dependencies automatically.
 2. Ensure the FastAPI backend is running.
 3. Start the server from the repository root:
    ```bash


### PR DESCRIPTION
## Summary
- clarify that fastmcp must be installed before running the MCP server
- mention `./setup.sh` automatically installs it

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5cbb706483319c6ff1e958deabbe